### PR TITLE
Serve static HTML instead of string for Login Success page

### DIFF
--- a/backend/public/login-success.html
+++ b/backend/public/login-success.html
@@ -1,0 +1,14 @@
+<h1>Login successful</h1>
+<a onclick="window.close()"> Click here if window does not close by itself in <span id="count"></span> seconds. </a>
+<script>
+  const domCount = document.querySelector('#count');
+  let countdown = 5;
+  domCount.textContent = countdown;
+  setInterval(() => {
+    countdown--;
+    domCount.textContent = countdown;
+    if (countdown === 0) {
+      window.close();
+    }
+  }, 1000);
+</script>

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -54,6 +54,7 @@ const wsUploadServer = new WebSocket.Server({ noServer: true });
 const wsMessageServer = new WebSocket.Server({ noServer: true });
 const app = express();
 
+app.use(express.static('public'));
 app.use(morgan('combined'));
 
 app.use(express.json({ limit: '5mb' }));

--- a/backend/src/routes/fxa.ts
+++ b/backend/src/routes/fxa.ts
@@ -141,25 +141,8 @@ router.get('/', async (req, res) => {
         res.status(500).json(err);
         return;
       }
-      res.status(200).send(`
-      <h1>Login successful</h1>
-      <a onclick="window.close()">
-        Click here if window does not close by itself in <span id="count"></span> seconds.
-      </a>
-      <script>
-        const domCount = document.querySelector('#count');
-        let countdown = 5;
-        domCount.textContent = countdown;
-        setInterval(() => {
-          countdown--;
-          domCount.textContent = countdown;
-          if (countdown === 0) {
-            window.close();
-          }
-        }, 1000)
-      </script>
 
-      `);
+      res.redirect('/login-success.html');
     });
   });
 });

--- a/frontend/src/Profile.vue
+++ b/frontend/src/Profile.vue
@@ -70,8 +70,6 @@ async function mozAcctLogin() {
 <template>
   <Btn @click.prevent="mozAcctLogin">Log into Moz Acct</Btn>
   <br />
-  <!-- <a href="/lockbox/fxa/logout">Log out of FXA</a> -->
-  <!-- <br /> -->
   <Btn @click.prevent="pingSession">ping session</Btn>
   <br />
   <br />

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
       '/echo': 'http://localhost:8080',
       '/api': 'http://localhost:8080',
       '/lockbox/fxa': 'http://backend:8080', // Using `backend` per the docker network name
+      '/login-success.html': 'http://backend:8080', // Using `backend` per the docker network name
     },
   },
   test: {


### PR DESCRIPTION
Closes #65

- Moz Account OIDC callback page now sends a `login-success.html` file instead of a hard-coded string.
- `login-success.html` remains unstyled until a more appropriate UI is designed.
- Added a proxy entry to the `vite.config.js` so that the page can be accessed while doing local dev.

