### PR TITLE
Add error codes to return from init()

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,12 +10,7 @@ const { keychain } = useKeychainStore();
 const folderStore = useFolderStore();
 
 onMounted(async () => {
-  /**
-   * Non-zero values indicate a specific error has occurred.
-   * All initialization error codes enumerated by`INIT_ERROR` in '@/lockbox/const'.
-   * @readonly
-   * @const {number}
-   */
+  // Non-zero values indicate a specific error has occurred.
   const errorCode = await init(userStore.user, keychain, folderStore);
 
   if (errorCode) {

--- a/frontend/src/lib/init.js
+++ b/frontend/src/lib/init.js
@@ -1,4 +1,4 @@
-import { INIT_ERROR } from '@/lockbox/const';
+import { INIT_ERRORS } from '@/lockbox/const';
 import { User } from '@/lib/user';
 import { Keychain } from '@/lib/keychain';
 
@@ -7,28 +7,29 @@ import { Keychain } from '@/lib/keychain';
  * @param {User} user - Instance of User class.
  * @param {Keychain} keychain - Instance of Keychain class.
  * @param {import('pinia').StoreDefinition} folderStore - Pinia store for managing folders.
+ * @return {INIT_ERRORS} - Returns 0 (success) or an error code typed by INIT_ERRORS.
  */
 async function init(user, keychain, folderStore) {
   const hasUser = await user.load();
   const hasKeychain = await keychain.load();
 
   if (!hasUser) {
-    return INIT_ERROR.NO_USER;
+    return INIT_ERRORS.NO_USER;
   }
 
   if (!hasKeychain) {
-    return INIT_ERROR.NO_KEYCHAIN;
+    return INIT_ERRORS.NO_KEYCHAIN;
   }
 
   await folderStore.sync();
   if (!folderStore.defaultFolder) {
     const createFolderResp = await folderStore.createFolder();
     if (!createFolderResp?.id) {
-      return INIT_ERROR.COULD_NOT_CREATE_DEFAULT_FOLDER;
+      return INIT_ERRORS.COULD_NOT_CREATE_DEFAULT_FOLDER;
     }
   }
 
-  return INIT_ERROR.NONE;
+  return INIT_ERRORS.NONE;
 }
 
 export default init;

--- a/frontend/src/lockbox/const.js
+++ b/frontend/src/lockbox/const.js
@@ -22,7 +22,7 @@ export const TagLabelColors = {
  * @readonly
  * @enum {number}
  */
-export const INIT_ERROR = {
+export const INIT_ERRORS = {
   NONE: 0,
   NO_USER: 1,
   NO_KEYCHAIN: 2,


### PR DESCRIPTION
Closes #66 

- Create codes for possible app initialization errors
- Return error code from `init()`
- In case of error, rehydrate user information from backend session