### PR TITLE
Remove remaining console.log() calls

### DIFF
--- a/backend/src/models/sharing.ts
+++ b/backend/src/models/sharing.ts
@@ -482,7 +482,6 @@ export async function burnFolder(
   shouldDeleteUpload?: boolean
 ) {
   // delete the ephemeral link
-  console.log(`🤡 burning container id: ${containerId}`);
   const findShareQuery = {
     where: {
       containerId,
@@ -509,8 +508,6 @@ export async function burnFolder(
       SHARE_NOT_DELETED
     );
   }
-
-  console.log(`✅ deleted ephemeral links`);
 
   // get the container so we can get the
   // - groups (so we can get users)
@@ -552,12 +549,10 @@ export async function burnFolder(
 
   const users = container.group.members.map(({ user }) => user);
 
-  console.log(`🤡 deleting items and uploads`);
   const uploadIds = container.items.map((item) => item.uploadId);
 
   await Promise.all(
     container.items.map(async ({ id }) => {
-      console.log(`✅ deleting item ${id}`);
       const deleteItemQuery = {
         where: {
           id,
@@ -571,7 +566,6 @@ export async function burnFolder(
   if (shouldDeleteUpload) {
     await Promise.all(
       uploadIds.map(async (id) => {
-        console.log(`✅ deleting upload ${id}`);
         const deleteUploadQuery = {
           where: {
             id,
@@ -598,7 +592,6 @@ export async function burnFolder(
     deleteContainerQuery,
     CONTAINER_NOT_DELETED
   );
-  console.log(`✅ deleting container ${containerId}`);
 
   await Promise.all(
     users.map(async ({ id, tier }) => {


### PR DESCRIPTION
Closes #92

 
This PR picks up where #90 left off:

```mermaid
flowchart BT
    A[ORM] --> |#94 Catch query errors| B
    B[Models] -->|#90 Throw custom error| C(Routes)
    C --> |#90 Send standard response codes| D[Front End]
    C --> |#92 Replace console.log| F[Error Log]
    D --> E[UI]
```

## Overview

Most of the `console.log()` calls were replaced with calls to the logging library (see #93).

The only ones left were in `backend/src/models/sharing.ts`.
This PR deletes them. (They were just developer-droppings.)
