### PR TITLE
Chore/149 use db push for prisma migration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "db:generate": "prisma generate",
     "db:browse": "prisma studio",
     "db:migrate": "prisma migrate dev",
-    "db:update": "prisma migrate deploy",
+    "db:update": "prisma db push",
     "db:reset": "prisma migrate reset",
     "test": "ava"
   },


### PR DESCRIPTION
Closes #149 

Description: 
This PR changes `migrate deploy` to `db push`

More information can be found [here](https://github.com/thunderbird/send-suite/issues/149)

Additional Notes:
This change shouldn't conflict with the previous implementation.