### PR TITLE
Feat/107 add deep linking on frontend

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,4 +23,11 @@ export default [
   ...tseslint.configs.recommended,
   ...pluginVue.configs['flat/recommended'],
   eslintConfigPrettier,
+  {
+    rules: {
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-extra-boolean-cast": "off",
+    }
+  }
 ];

--- a/frontend/src/apps/lockbox/components/Breadcrumbs.vue
+++ b/frontend/src/apps/lockbox/components/Breadcrumbs.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue';
 import useFolderStore from '@/apps/lockbox/stores/folder-store';
+import { ref, watchEffect } from 'vue';
+import { useRouter } from 'vue-router';
 const folderStore = useFolderStore();
 
 const path = ref([]);
+
+const router = useRouter();
 
 watchEffect(() => {
   path.value = [folderStore.rootFolder];
@@ -18,11 +21,19 @@ watchEffect(() => {
 <template>
   <ul>
     <li class="inline-block pl-1">
-      <button @click="folderStore.goToRootFolder(null)">🏠</button>
+      <button @click="router.push('/lockbox')">🏠</button>
     </li>
-    <li v-if="folderStore.rootFolder" v-for="node of path" class="inline-block pl-1">
+    <li
+      v-for="node of path"
+      v-if="folderStore.rootFolder"
+      class="inline-block pl-1"
+    >
       &nbsp;&gt;&nbsp;
-      <button @click.prevent="folderStore.goToRootFolder(node.id)">
+      <button
+        @click.prevent="
+          router.push({ name: 'folder', params: { id: node.id } })
+        "
+      >
         {{ node.name }}
       </button>
     </li>

--- a/frontend/src/apps/lockbox/components/FolderNavigation.vue
+++ b/frontend/src/apps/lockbox/components/FolderNavigation.vue
@@ -1,17 +1,6 @@
 <script setup lang="ts">
-import { inject, ref } from 'vue';
 import useFolderStore from '@/apps/lockbox/stores/folder-store';
 
-import {
-  IconRefresh,
-  IconPlus,
-  IconDots,
-  IconDotsVertical,
-  IconTag,
-  IconFolder,
-  IconFileText,
-} from '@tabler/icons-vue';
-import Btn from '@/apps/lockbox/elements/Btn.vue';
 import DragAndDropUpload from '@/apps/lockbox/components/DragAndDropUpload.vue';
 
 const folderStore = useFolderStore();
@@ -20,11 +9,7 @@ const folderStore = useFolderStore();
 <template>
   <div class="flex flex-col gap-6 h-full">
     <!-- actions -->
-    <header class="flex items-center justify-between pt-2 px-2.5">
-      <!-- <Btn class="!px-1.5"><IconRefresh class="w-4 h-4" /></Btn> -->
-      <!-- <Btn primary><IconPlus class="w-4 h-4" /> New Upload</Btn> -->
-      <!-- <Btn class="!px-1.5"><IconDots class="w-4 h-4" /></Btn> -->
-    </header>
+    <header class="flex items-center justify-between pt-2 px-2.5"></header>
     <!-- upload zone -->
     <section class="px-2.5">
       <DragAndDropUpload v-if="folderStore.rootFolder">
@@ -41,55 +26,10 @@ const folderStore = useFolderStore();
         <li>
           <router-link to="/lockbox">My Files</router-link>
         </li>
-        <!-- <li>
-          <router-link to="/lockbox/sent">Sent</router-link>
-        </li>
-        <li>
-          <router-link to="/lockbox/received">Received</router-link>
-        </li> -->
         <li>
           <router-link to="/lockbox/profile">Profile</router-link>
         </li>
       </ul>
     </section>
-    <!-- recent activity -->
-    <!-- <RecentActivity /> -->
-    <!-- tags -->
-    <!-- <section class="flex flex-col gap-2 p-2.5 border-t border-gray-300">
-      <div class="flex justify-between items-center">
-        <div class="font-semibold text-lg text-gray-900">Tags</div>
-        <Btn class="!px-1.5"><IconDotsVertical class="w-4 h-4" /></Btn>
-      </div>
-      <div class="flex flex-col gap-1 pl-3">
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-red-500 fill-red-500/20" />
-          <span class="text-gray-800 pb-1">Important</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-orange-600 fill-orange-600/20" />
-          <span class="text-gray-800 pb-1">Work</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-green-600 fill-green-600/20" />
-          <span class="text-gray-800 pb-1">Personal</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-blue-600 fill-blue-600/20" />
-          <span class="text-gray-800 pb-1">Todo</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-fuchsia-600 fill-fuchsia-600/20" />
-          <span class="text-gray-800 pb-1">Later</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-teal-600 fill-teal-600/20" />
-          <span class="text-gray-800 pb-1">Upgrade</span>
-        </div>
-        <div class="flex gap-2 items-center">
-          <IconTag class="w-5 h-5 !stroke-pink-600 fill-pink-600/20" />
-          <span class="text-gray-800 pb-1">Party 🎉</span>
-        </div>
-      </div>
-    </section> -->
   </div>
 </template>

--- a/frontend/src/apps/lockbox/components/FolderView.vue
+++ b/frontend/src/apps/lockbox/components/FolderView.vue
@@ -1,67 +1,92 @@
+<!-- eslint-disable vue/no-use-v-if-with-v-for -->
 <script setup lang="ts">
-import { inject } from 'vue';
 import { DayJsKey } from '@/types';
+import { inject, onMounted, watch } from 'vue';
 
 import useFolderStore from '@/apps/lockbox/stores/folder-store';
 
-import { IconDownload, IconTrash, IconDotsVertical } from '@tabler/icons-vue';
-import FolderTableRowCell from '@/apps/lockbox/elements/FolderTableRowCell.vue';
+import Breadcrumbs from '@/apps/lockbox/components/BreadCrumbs.vue';
 import Btn from '@/apps/lockbox/elements/Btn.vue';
-import Breadcrumbs from '@/apps/lockbox/components/Breadcrumbs.vue';
+import FolderTableRowCell from '@/apps/lockbox/elements/FolderTableRowCell.vue';
+import { IconDotsVertical, IconDownload, IconTrash } from '@tabler/icons-vue';
+import { useDebounceFn } from '@vueuse/core';
+import { useRoute, useRouter } from 'vue-router';
 
 const folderStore = useFolderStore();
 
 const dayjs = inject(DayJsKey);
 
-// onMounted(getVisibleFolders);
-// onMounted(folderStore.fetchUserFolders);
+const route = useRoute();
+const router = useRouter();
+
+const gotoRoute = useDebounceFn(() => {
+  const id = Number(route.params.id);
+  if (!!id) {
+    folderStore.goToRootFolder(id);
+    return;
+  }
+  folderStore.goToRootFolder(null);
+}, 1);
+
+onMounted(() => {
+  gotoRoute();
+});
+
+watch(
+  () => route.params.id,
+  (newId, oldId) => {
+    if (newId !== oldId) {
+      gotoRoute();
+    }
+  }
+);
+</script>
+<script lang="ts">
+export default { props: { id: { type: String, default: 'null' } } };
 </script>
 <template>
   <div class="w-full flex flex-col gap-3">
     <h2 class="font-bold">Your Files</h2>
     <Breadcrumbs />
-    <!-- <DragAndDropUpload> -->
     <table class="w-full border-separate border-spacing-x-0 border-spacing-y-1">
       <thead>
         <tr>
           <th class="border-r border-b border-gray-300"></th>
           <th class="border-r border-b border-gray-300">Name</th>
-          <!-- <th class="border-r border-b border-gray-300">Tags</th> -->
-          <!-- <th class="border-r border-b border-gray-300">Shared With</th> -->
           <th class="border-b border-gray-300"></th>
         </tr>
       </thead>
       <tbody>
         <tr
-          class="group cursor-pointer"
           v-for="folder in folderStore.visibleFolders"
           :key="folder.id"
+          class="group cursor-pointer"
           @click="folderStore.setSelectedFolder(folder.id)"
-          @dblclick="folderStore.goToRootFolder(folder.id)"
+          @dblclick="router.push({ name: 'folder', params: { id: folder.id } })"
         >
-          <FolderTableRowCell :selected="folder.id === folderStore.selectedFolder?.id">
+          <FolderTableRowCell
+            :selected="folder.id === folderStore.selectedFolder?.id"
+          >
             <img src="@/apps/lockbox/assets/folder.svg" class="w-8 h-8" />
           </FolderTableRowCell>
-          <FolderTableRowCell :selected="folder.id === folderStore.selectedFolder?.id">
+          <FolderTableRowCell
+            :selected="folder.id === folderStore.selectedFolder?.id"
+          >
             <div>{{ folder.name }}</div>
-            <div class="text-sm">Last modified {{ dayjs().to(dayjs(folder.updatedAt)) }}</div>
-          </FolderTableRowCell>
-          <!-- <FolderTableRowCell :selected="folder.id === folderStore.selectedFolder?.id">
-            <div class="flex">
-              <Tag v-for="tag in folder.tags" :color="tag.color" />
+            <div class="text-sm">
+              Last modified {{ dayjs().to(dayjs(folder.updatedAt)) }}
             </div>
-          </FolderTableRowCell> -->
-          <!-- <FolderTableRowCell :selected="folder.id === folderStore.selectedFolder?.id"></FolderTableRowCell> -->
-          <FolderTableRowCell :selected="folder.id === folderStore.selectedFolder?.id">
+          </FolderTableRowCell>
+          <FolderTableRowCell
+            :selected="folder.id === folderStore.selectedFolder?.id"
+          >
             <div class="flex justify-between">
               <div
                 class="flex gap-2 opacity-0 group-hover:!opacity-100 transition-opacity"
-                :class="{ '!opacity-100': folder.id === folderStore.selectedFolder?.id }"
+                :class="{
+                  '!opacity-100': folder.id === folderStore.selectedFolder?.id,
+                }"
               >
-                <!-- <Btn secondary>
-                  <IconDownload class="w-4 h-4" />
-                </Btn> -->
-                <!-- <Btn primary> <IconShare class="w-4 h-4" /> Share </Btn> -->
                 <Btn danger @click="folderStore.deleteFolder(folder.id)">
                   <IconTrash class="w-4 h-4" />
                 </Btn>
@@ -73,10 +98,10 @@ const dayjs = inject(DayJsKey);
           </FolderTableRowCell>
         </tr>
         <tr
-          class="group cursor-pointer"
-          v-if="folderStore.rootFolder"
           v-for="item in folderStore.rootFolder.items"
+          v-if="folderStore.rootFolder"
           :key="item.id"
+          class="group cursor-pointer"
           @click="folderStore.setSelectedFile(item.id)"
         >
           <FolderTableRowCell>
@@ -86,22 +111,34 @@ const dayjs = inject(DayJsKey);
           </FolderTableRowCell>
           <FolderTableRowCell>
             <div>{{ item.name }}</div>
-            <div class="text-sm">Last modified {{ dayjs().to(dayjs(item.updatedAt)) }}</div>
+            <div class="text-sm">
+              Last modified {{ dayjs().to(dayjs(item.updatedAt)) }}
+            </div>
           </FolderTableRowCell>
           <FolderTableRowCell>
             <div class="flex justify-between">
-              <div class="flex gap-2 opacity-0 group-hover:!opacity-100 transition-opacity">
+              <div
+                class="flex gap-2 opacity-0 group-hover:!opacity-100 transition-opacity"
+              >
                 <Btn
                   secondary
-                  @click="folderStore.downloadContent(item.uploadId, item.containerId, item.wrappedKey, item.name)"
+                  @click="
+                    folderStore.downloadContent(
+                      item.uploadId,
+                      item.containerId,
+                      item.wrappedKey,
+                      item.name
+                    )
+                  "
                 >
                   <IconDownload class="w-4 h-4" />
                 </Btn>
-                <!-- <Btn primary>
-                  <IconShare class="w-4 h-4" />
-                  Share
-                </Btn> -->
-                <Btn danger @click="folderStore.deleteItem(item.id, folderStore.rootFolder.id)">
+                <Btn
+                  danger
+                  @click="
+                    folderStore.deleteItem(item.id, folderStore.rootFolder.id)
+                  "
+                >
                   <IconTrash class="w-4 h-4" />
                 </Btn>
               </div>
@@ -113,6 +150,5 @@ const dayjs = inject(DayJsKey);
         </tr>
       </tbody>
     </table>
-    <!-- </DragAndDropUpload> -->
   </div>
 </template>

--- a/frontend/src/apps/lockbox/router.ts
+++ b/frontend/src/apps/lockbox/router.ts
@@ -1,15 +1,15 @@
 import { RouteRecordRaw, createRouter, createWebHistory } from 'vue-router';
 
-import Lockbox from '@/apps/lockbox/pages/Web.vue';
 import FolderView from '@/apps/lockbox/components/FolderView.vue';
 import Profile from '@/apps/lockbox/components/Profile.vue';
-import Sent from '@/apps/lockbox/components/Sent.vue';
 import Received from '@/apps/lockbox/components/Received.vue';
+import Sent from '@/apps/lockbox/components/Sent.vue';
+import Lockbox from '@/apps/lockbox/pages/Web.vue';
 
-import Share from '@/apps/lockbox/pages/Share.vue';
 import Recovery from '@/apps/common/Recovery.vue';
+import Share from '@/apps/lockbox/pages/Share.vue';
 
-const routes: RouteRecordRaw[] = [
+export const routes: RouteRecordRaw[] = [
   {
     path: '/lockbox',
     component: Lockbox,
@@ -18,6 +18,12 @@ const routes: RouteRecordRaw[] = [
       { path: 'profile', component: Profile },
       { path: 'sent', component: Sent },
       { path: 'received', component: Received },
+      {
+        path: 'folder/:id',
+        component: FolderView,
+        props: true,
+        name: 'folder',
+      },
     ],
   },
 

--- a/frontend/src/apps/lockbox/stores/folder-store.ts
+++ b/frontend/src/apps/lockbox/stores/folder-store.ts
@@ -1,18 +1,18 @@
-import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
-import useApiStore from '@/stores/api-store';
-import useUserStore from '@/stores/user-store';
-import useKeychainStore from '@/stores/keychain-store';
-import Uploader from '@/lib/upload';
-import Downloader from '@/lib/download';
 import { CONTAINER_TYPE } from '@/lib/const';
+import Downloader from '@/lib/download';
+import Uploader from '@/lib/upload';
+import useApiStore from '@/stores/api-store';
+import useKeychainStore from '@/stores/keychain-store';
+import useUserStore from '@/stores/user-store';
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
 
 import {
   Folder,
   FolderResponse,
+  FolderStore,
   Item,
   ItemResponse,
-  FolderStore,
 } from '@/apps/lockbox/stores/folder-store.types';
 import { NamedBlob } from '@/lib/filesync';
 
@@ -255,7 +255,7 @@ function calculateFolderSizes(folders: Folder[]): Folder[] {
   // Otherwise, we'd have to fetch all descendents in order
   // to do the full calculation.
   const foldersWithSizes = folders.map((folder) => {
-    let size =
+    const size =
       folder.items?.reduce(
         (total, { upload }) => total + upload?.size || 0,
         0
@@ -275,7 +275,7 @@ function findNode(
     return null;
   }
 
-  for (let node of collection) {
+  for (const node of collection) {
     if (node.id === id) {
       return node;
     }

--- a/frontend/src/test/apps/lockbox/components/FolderVue.test.ts
+++ b/frontend/src/test/apps/lockbox/components/FolderVue.test.ts
@@ -1,0 +1,68 @@
+import FolderView from '@/apps/lockbox/components/FolderView.vue';
+import { routes } from '@/apps/lockbox/router';
+import { DayJsKey } from '@/types';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { createRouter, createWebHistory } from 'vue-router';
+
+let router;
+let wrapper;
+
+const { goToRootFolderSpy } = vi.hoisted(() => {
+  return { goToRootFolderSpy: vi.fn() };
+});
+
+// Setup testing environment
+vi.mock('@/apps/lockbox/stores/folder-store', () => {
+  return {
+    esmodule: true,
+    default: vi.fn(() => ({
+      goToRootFolder: goToRootFolderSpy,
+    })),
+  };
+});
+vi.useFakeTimers();
+
+describe('FolderView', () => {
+  beforeEach(() => {
+    router = createRouter({
+      history: createWebHistory(),
+      routes,
+    });
+
+    wrapper = mount(FolderView, {
+      global: {
+        plugins: [router],
+        provide: {
+          //@ts-ignore
+          [DayJsKey]: () => ({ to: () => 'a while ago' }),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders correctly and reacts to route changes', async () => {
+    expect(wrapper.text()).toContain('Your Files');
+
+    // Trigger route change
+    await router.push({ name: 'folder', params: { id: '0' } });
+    await wrapper.vm.$nextTick();
+
+    // Advance timers for debounced functions
+    // This is VERY IMPORTANT to make sure the debounced function is called
+    vi.runAllTimers();
+
+    // Check if goToRootFolder was called with new id
+    expect(goToRootFolderSpy).toBeCalledWith(null);
+
+    await router.push({ name: 'folder', params: { id: '123' } });
+    await wrapper.vm.$nextTick();
+    vi.runAllTimers();
+
+    expect(goToRootFolderSpy).toBeCalledWith(123);
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,8 +1,10 @@
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
 import { defineConfig } from 'vite';
 import viteConfig from './vite.config';
-import path from 'path';
 
 export default defineConfig({
+  plugins: [vue()],
   viteConfig,
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #107 

This PR adds URL navigation (deep linking) for folders.

### Overview:
- Added navigation using router extending the existing logic
- Added test coverage for folder navigation using router
- Changed `eslint` rules to allow `ts` annotations
- Added vue configuration to vitest


### Testing Strategy:

- Tested accessing different folders by clicking on them and verifying the contents displayed.
- Tested accessing specific folders by manually entering the folder number in the URL and confirming redirection.
- Tested navigating back to previous folders using the breadcrumbs feature.
- Verified that clicking on files does not trigger any action, as expected.
- Tested double-clicking the home icon to navigate back to the root folder.


Little demo [here](https://www.loom.com/share/56c8b525b1924aeba10e7afb23217c46?sid=30b67ceb-4061-40a3-984b-14a8f897a018)