### PR TITLE
Set up an S3-backed CloudFront distribution for static assets

### DIFF
--- a/pulumi/cloudfront-rewrite.js
+++ b/pulumi/cloudfront-rewrite.js
@@ -1,0 +1,23 @@
+async function handler(event) {
+  const request = event.request;
+  const apiPath = "/api";
+  const ignorePaths = ['/lockbox/fxa', '/assets', '/sitemap.txt'];
+  const pathCheckFn = (path) => request.uri.startsWith(path);
+
+  // If our api path is the first thing that's found in the uri then remove it from the uri.
+  if (request.uri.indexOf(apiPath) === 0) {
+    request.uri = request.uri.replace(apiPath, "");
+  } else if (!ignorePaths.some(pathCheckFn)) {
+    // If we're not in one of the ignorePaths then force them to /index.html
+    request.uri = '/index.html';
+  }
+
+  // If empty, then add a slash!
+  // Required by AWS, see https://github.com/thunderbird/appointment/pull/510/
+  if (request.uri === '') {
+    request.uri = '/';
+  }
+
+  // else carry on like normal.
+  return request;
+}

--- a/pulumi/config.staging.yaml
+++ b/pulumi/config.staging.yaml
@@ -168,3 +168,14 @@ resources:
                 value: send-suite-backend
               - name: STORAGE_BACKEND
                 value: b2
+
+  tb:cloudfront:CloudFrontS3Service:
+    frontend:
+      service_bucket_name: tb-send-suite-staging-frontend
+      certificate_arn: arn:aws:acm:us-east-1:768512802988:certificate/3a98e226-c4df-4e58-bc0a-aa4ccbf6325e
+      distribution:
+        aliases:
+          - send.thunderbird.dev
+        comment: send-suite staging frontend
+        logging_config:
+          include_cookies: True

--- a/pulumi/pyproject.toml
+++ b/pulumi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "send-suite-pulumi"
-version = "0.0.1"
+version = "0.0.2"
 description = "Pulumi-built infrastructure for send-suite"
 requires-python = ">3.12"
 dynamic = ["dependencies"]

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/thunderbird/pulumi.git@v0.0.1
+git+https://github.com/thunderbird/pulumi.git@v0.0.2


### PR DESCRIPTION
This PR depends upon [Pulumi PR #5](https://github.com/thunderbird/pulumi/pull/5), and upon a `v0.0.2` branch cut from that once merged.

This brings the frontend infrastructure built to support the Send-Suite Alpha under Pulumi control.