### PR TITLE
Invalidate the CDN when frontend code gets deployed

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -172,7 +172,7 @@ jobs:
           echo "archive_filename=$ARCHIVE" >> $GITHUB_OUTPUT
 
           # Invalidate the CDN
-          aws cloudfront create-invalidation --distribution-id $STAGING_CF_DISTRO_ID --paths "/*"
+          aws cloudfront create-invalidation --distribution-id ${{ vars.STAGING_CF_DISTRO_ID }} --paths "/*"
 
       - name: Archive the build
         id: frontend-archive


### PR DESCRIPTION
I have added the distribution ID as a variable to this repo.