### PR TITLE
move offending ts file

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "",
   "keywords": [],
   "license": "ISC",
@@ -25,7 +25,7 @@
     "test": "vitest run --silent",
     "test:watch": "vitest --watch",
     "typecheck": "tsc --noEmit",
-    "postversion": "bun run ./scripts/bump.ts"
+    "postversion": "bun run ./src/scripts/bump.ts"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/backend/src/scripts/bump.ts
+++ b/backend/src/scripts/bump.ts
@@ -8,10 +8,10 @@ interface PackageJson {
 async function updateYamlConfig(): Promise<void> {
   try {
     // Define relative paths from current directory
-    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonPath = path.resolve(__dirname, '../../package.json');
     const yamlConfigPath = path.resolve(
       __dirname,
-      '../../pulumi/config.staging.yaml'
+      '../../../pulumi/config.staging.yaml'
     );
 
     // Read and parse package.json

--- a/pulumi/config.staging.yaml
+++ b/pulumi/config.staging.yaml
@@ -86,7 +86,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:0.1.23
+            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:0.1.24
             desired_replicas: 1
             portMappings:
               - name: send-suite


### PR DESCRIPTION
This change is important. I noticed that having a ts file outside of the src folder will mess the results from `tsc` hence breaking the app.