### PR TITLE
add version numbers to artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ venv
 /blob-report/
 /playwright/.cache/
 /data
-/frontend-source.zip
+/frontend-source*

--- a/frontend/scripts/build.sh
+++ b/frontend/scripts/build.sh
@@ -3,9 +3,11 @@ if [ "$NODE_ENV" = "production" ]; then
     echo 'Starting production build 🐧'
 fi
 
+# Get version from package.json and replace dots with hyphens
+VERSION=$(node -p "require('./package.json').version.replace(/\./g, '-')")
+
 # Remove old builds
 rm -rf dist && rm -rf dist-web
-rm ../send-suite-alpha.xpi
 rm -rf send-suite-alpha
 
 mkdir -p dist/assets
@@ -27,8 +29,8 @@ rm -rf dist/pages
 
 cd dist
 
-# Create xpi
-zip -r -FS ../send-suite-alpha.xpi * 
+# Create xpi with version number
+zip -r -FS ../send-suite-alpha-${VERSION}.xpi * 
 
 echo 'Add-on build complete 🎉'
 

--- a/frontend/scripts/submit.sh
+++ b/frontend/scripts/submit.sh
@@ -2,6 +2,9 @@ cd ..
 
 mkdir frontend-source
 
+# Get version from package.json and replace dots with hyphens
+VERSION=$(node -p "require('./frontend/package.json').version.replace(/\./g, '-')")
+
 # Copy only necessary files
 cp -r frontend/src frontend-source/src
 cp -r frontend/public frontend-source/public
@@ -23,12 +26,12 @@ mkdir frontend-source/scripts
 cp frontend/scripts/build.sh frontend-source/scripts/build.sh
 
 # Create zip for submission
-zip -r frontend-source.zip frontend-source
+zip -r frontend-source-${VERSION}.zip frontend-source
 # Remove the directory
 rm -rf frontend-source
 
 mv frontend/send-suite-alpha.xpi  send-suite-alpha.xpi
 
-echo "Finished creating frontend-source.zip!"
+echo "Finished creating frontend-source-${VERSION}.zip!"
 
 


### PR DESCRIPTION
This pull request includes changes to the build and submission scripts to incorporate versioning based on the `package.json` file. The most important changes include extracting the version from `package.json`, updating the build and submission scripts to use this version, and ensuring the generated files include the version number.

Versioning updates:

* [`frontend/scripts/build.sh`](diffhunk://#diff-f8721c5e7c36040401110a11474100b49a5281a2c3cf9341ae40aef1ba56305fR6-L8): Extracted the version from `package.json` and used it to name the build output files, replacing dots with hyphens. [[1]](diffhunk://#diff-f8721c5e7c36040401110a11474100b49a5281a2c3cf9341ae40aef1ba56305fR6-L8) [[2]](diffhunk://#diff-f8721c5e7c36040401110a11474100b49a5281a2c3cf9341ae40aef1ba56305fL30-R33)
* [`frontend/scripts/submit.sh`](diffhunk://#diff-cd2ab194fd79a3651908b718f6995998831772be8dd02391a33ee50fc822679eR5-R7): Extracted the version from `package.json` and used it to name the submission zip file, replacing dots with hyphens. [[1]](diffhunk://#diff-cd2ab194fd79a3651908b718f6995998831772be8dd02391a33ee50fc822679eR5-R7) [[2]](diffhunk://#diff-cd2ab194fd79a3651908b718f6995998831772be8dd02391a33ee50fc822679eL26-R35)