### PR TITLE
Add production deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,106 @@
+---
+name: deploy-production
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download ECR tag artifact
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: ${{ github.event.release.id }}
+          file: ecr_tag.zip
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Retag image
+        id: retag-image
+        shell: bash
+        run: |
+          # Gather info
+          unzip ecr_tag.zip  # Produces ecr_tag.txt
+          source_tag=$(cat ecr_tag.txt)
+          cd backend
+          semver=$(jq -r .version < package.json)
+          target_tag="${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:$semver"
+
+          # Output the target tag
+          echo "target_tag=$target_tag" >> $GITHUB_OUTPUT
+
+          # Retag the image and push it
+          docker pull $source_tag
+          docker tag $source_tag $target_tag
+          docker push $target_tag
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Set up virtual environment
+        shell: bash
+        run: |
+          python -m pip install virtualenv
+          cd pulumi
+          virtualenv ./venv
+
+      - name: Set up Pulumi environment
+        id: pulumi-env
+        shell: bash
+        run: |
+          cd pulumi
+          source ./venv/bin/activate
+          curl -fsSL https://get.pulumi.com | sh
+          pip install -Ur requirements.txt
+
+      - name: Deploy version-tagged image to prod
+        shell: bash
+        run: |
+          # Pull the versioned tag from the previous step
+          target_tag="${{ steps.retag-image.outputs.target_tag }}"
+
+          # Change the image config option and try to apply the change
+          cd pulumi
+          cat << EOF > newimage.yaml
+          resources:
+            tb:fargate:FargateClusterWithLogging:
+              backend:
+                task_definition:
+                  container_definitions:
+                    backend:
+                      image: "$target_tag"
+          EOF
+          yq -i '. *= load("newimage.yaml")' config.prod.yaml
+          export PULUMI_CONFIG_PASSPHRASE='${{ secrets.PULUMI_PASSPHRASE_PROD }}'
+          source ./venv/bin/activate
+          pulumi login s3://tb-send-suite-pulumi
+          pulumi stack select prod
+          TBPULUMI_DISABLE_PROTECTION=True \
+            pulumi up -y --diff --target \
+            'urn:pulumi:prod::send-suite::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::send-suite-prod-fargate-taskdef' \
+            --target-dependents

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,6 +90,14 @@ jobs:
           docker build -t $ECR_TAG ./backend
           docker push $ECR_TAG
           echo "backend-image=$ECR_TAG" >> $GITHUB_OUTPUT
+          echo -n "$ECR_TAG" > ecr_tag.txt
+
+      - name: Archive the ECR tag
+        id: tag-archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecr_tag
+          path: ecr_tag.txt
 
       # Deploy to staging
       - name: Deploy new image to staging
@@ -116,14 +124,6 @@ jobs:
           pulumi up -y --diff --target \
             'urn:pulumi:staging::send-suite::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::send-suite-staging-fargate-taskdef' \
             --target-dependents
-
-          # Only push the config change back to the repo if it was successfully applied
-          # Don't do this, at least for now
-          # git config --global user.email 'services-dev@thunderbird.net'
-          # git config --global user.name 'GitHub Actions Workflow Automation'
-          # git add config.staging.yaml
-          # git commit -m "CI: Update staging image"
-          # git push
 
   frontend-merge:
     needs: detect-changes

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -142,12 +142,15 @@ ci_iam = tb_pulumi.ci.AwsAutomationUser(
     enable_ecr_image_push=True,
     ecr_repositories=['send'],
     enable_fargate_deployments=True,
-    fargate_clusters=['send-suite-staging-fargate'],
-    fargate_task_role_arns=['arn:aws:iam::768512802988:role/send-suite-staging-fargate'],
+    fargate_clusters=['send-suite-staging-fargate', 'send-suite-prod-fargate'],
+    fargate_task_role_arns=[
+        'arn:aws:iam::768512802988:role/send-suite-staging-fargate',
+        'arn:aws:iam::768512802988:role/send-suite-prod-fargate',
+    ],
     enable_full_s3_access=True,
     s3_full_access_buckets=['tb-send-suite-pulumi'],
     enable_s3_bucket_upload=True,
-    s3_upload_buckets=['tb-send-suite-staging-frontend'],
+    s3_upload_buckets=['tb-send-suite-staging-frontend', 'tb-send-suite-prod-frontend'],
     opts=pulumi.ResourceOptions(depends_on=[frontend]),
 )
 

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -1,5 +1,8 @@
 ---
 resources:
+  domains:
+    backend: send-backend-prod.thunderbird.dev
+    frontend: send-frontend-prod.thunderbird.dev
   tb:network:MultiCidrVpc:
     vpc:
       cidr_block: 10.100.0.0/16
@@ -167,6 +170,12 @@ resources:
         comment: send-suite prod frontend
         logging_config:
           include_cookies: True
-  domains:
-    backend: send-backend-prod.thunderbird.dev
-    frontend: send-frontend-prod.thunderbird.dev
+  tb:cloudwatch:CloudWatchMonitoringGroup:
+    alarms: {}
+    notify_emails:
+      - rjung+cloudwatch@thunderbird.net
+    # alarms:
+    #   send-suite-staging-fargate-service:
+    #     cpu_utilization:
+    #       enabled: False
+    #       threshold: 80

--- a/pulumi/config.staging.yaml
+++ b/pulumi/config.staging.yaml
@@ -86,7 +86,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: "768512802988.dkr.ecr.us-east-1.amazonaws.com/send:46485f8b489f84128f8a03a988423fba37850bb8"
+            image: "768512802988.dkr.ecr.us-east-1.amazonaws.com/send:3a22c15a4baa7528657e88726e3ef0f730827d02"
             portMappings:
               - name: send-suite
                 containerPort: 8080


### PR DESCRIPTION
This should get us started by deploying the backend to production when we create a release using the ECR tag artifact of a previous build.