### PR TITLE
add retention rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,6 @@ Move to the b2 rules directory
 
 Update the rules
 `b2 bucket update {YOUR_BUCKET_NAME} --cors-rules "$(<./rules.json)"`
+
+Updating retention rules
+`b2 bucket update {YOUR_BUCKET_NAME} --lifecycle-rule "$(<./retention.json)"`

--- a/backend/b2/retention.json
+++ b/backend/b2/retention.json
@@ -1,0 +1,5 @@
+{
+  "daysFromHidingToDeleting": 30,
+  "daysFromUploadingToHiding": 15,
+  "fileNamePrefix": "backup/"
+}


### PR DESCRIPTION
This pull request includes changes to update the documentation and add a new retention policy for B2 buckets. The most important changes include updating the `README.md` file to include instructions for updating retention rules and adding a new `retention.json` file with specific lifecycle rules.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R286): Added instructions for updating retention rules using the `b2 bucket update` command.

New retention policy:

* [`backend/b2/retention.json`](diffhunk://#diff-e0831bc7d5ec29a46a796566485da7ed95e0866e4c63aded220b07adde70aaabR1-R5): Added a new JSON file specifying retention rules, including days from hiding to deleting, days from uploading to hiding, and a file name prefix for backups.