### PR TITLE
Fix file naming conflicts in frontend builds

### DIFF
--- a/frontend/scripts/submit.sh
+++ b/frontend/scripts/submit.sh
@@ -32,10 +32,13 @@ mkdir frontend-source/scripts
 cp frontend/scripts/build.sh frontend-source/scripts/build.sh
 
 # Create zip for submission
-zip -r frontend-source-${VERSION}.zip frontend-source
-
 if [ "$IS_CI_AUTOMATION" != "yes" ]; then
+    # Is *not* CI automation; is probably local dev
+    zip -r frontend-source-${VERSION}.zip frontend-source
     rm -rf frontend-source
+    echo "Finished creating frontend-source-${VERSION}.zip!"
+else
+    # *IS* CI automation
+    zip -r frontend-source.zip frontend-source
+    echo "Finished creating frontend-source.zip!"
 fi
-
-echo "Finished creating frontend-source-${VERSION}.zip!"


### PR DESCRIPTION
It may be helpful for local development to have versioned outputs from builds. It is helpful for CI, though, to have consistently named files. So we'll do things differently based on which of these modes the submit script is operating in.