### PR TITLE
chore: bump backend version to 0.1.33

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "",
   "keywords": [],
   "license": "ISC",
@@ -25,8 +25,7 @@
     "start": "NODE_ENV=production node dist/index.js",
     "test": "vitest run --silent",
     "test:watch": "vitest --watch",
-    "typecheck": "tsc --noEmit",
-    "postversion": "bun run ./src/scripts/bump.ts"
+    "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
This pull request includes minor version updates and the removal of a postversion script in the `backend/package.json` file.

*Version update:*

* Updated the version from `0.1.32` to `0.1.33` in `backend/package.json`.

*Script removal:*

* Removed the `postversion` script from `backend/package.json`.