### PR TITLE
Only track .env.sample files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@ seed.ts
 .pnpm-store
 
 
-# Dev droppings
-.env
-.env.production
-.fenv*
+# Do not track .env files and variants
+.*env*
+# Only track .env.sample
+!.env.sample
+
 dev.db*
 shell.nix*
 node_modules


### PR DESCRIPTION
To avoid committing sensitive values via `.env` files. We only allow `.env.sample` to be committed 