### PR TITLE
chore: bump backend version to 0.1.36

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "",
   "keywords": [],
   "license": "ISC",


### PR DESCRIPTION
release the backend 🦀 