### PR TITLE
Pin Pulumi to special branch

### DIFF
--- a/pulumi/config.staging.yaml
+++ b/pulumi/config.staging.yaml
@@ -86,7 +86,7 @@ resources:
           - FARGATE
         container_definitions:
           backend:
-            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:43061258d5d77f69b01303f1d9432f0254c9880b
+            image: 768512802988.dkr.ecr.us-east-1.amazonaws.com/send:d3d0d713d2423c83225e7df8cac419787e7d2757
             portMappings:
               - name: send-suite
                 containerPort: 8080

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,2 +1,2 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.10
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.10-sendci
 pulumi_cloudflare==5.48.0


### PR DESCRIPTION
There was [a bug in CI permissions](https://github.com/thunderbird/pulumi/issues/79), but that has been solved. The problem is that it has been applied here (that's how we know it works), but the tb_pulumi version that is needed to keep these permissions is gone. CI keeps removing its own access and then failing to deploy. This pins tb_pulumi to a temporary version that keeps CI running while the next proper version is developed.