### PR TITLE
add migration for access link locking

### DIFF
--- a/backend/prisma/migrations/20250130173835_add_password_attempt_lock/migration.sql
+++ b/backend/prisma/migrations/20250130173835_add_password_attempt_lock/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "AccessLink" ADD COLUMN     "locked" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "passwordHash" TEXT,
+ADD COLUMN     "retryCount" INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
This pull request includes changes to the `backend/prisma/migrations/20250130173835_add_password_attempt_lock/migration.sql` file to enhance security features by adding password attempt lock functionality.

Database schema changes:

* Added a `locked` column to the `AccessLink` table to indicate if the account is locked.
* Added a `passwordHash` column to store the hashed password.
* Added a `retryCount` column to track the number of failed login attempts.