### PR TITLE
upload prod xpi

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -243,6 +243,7 @@ jobs:
           popd
           mv frontend-source frontend-source-prod
           mv frontend-source.zip frontend-source-prod.zip
+          mv "$(find send-suite-*.xpi)" "send-suite-prod-$(basename "$(find send-suite-*.xpi)" | cut -d'-' -f3-)"
 
       - name: Archive the production frontend build
         id: frontend-archive-prod
@@ -277,4 +278,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: xpi-prod
-          path: send-suite-alpha-*.xpi
+          path: send-suite-prod-*.xpi


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/merge.yml` file to update the handling of production files.

Improvements to production file handling:

* Updated the script to rename the `send-suite` file to follow the production naming convention.
* Changed the artifact upload path to use the production naming convention for `send-suite` files.