### PR TITLE
add base url env to merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -179,6 +179,8 @@ jobs:
 
       - name: Build the staging frontend's static assets
         id: frontend-build-staging
+        env:
+          BASE_URL: https://send.thunderbird.dev
         shell: bash
         run: |
           # Initial setup of dependencies
@@ -231,6 +233,8 @@ jobs:
       - name: Build the production frontend's static assets
         id: frontend-build-prod
         shell: bash
+        env:
+          BASE_URL: https://send.tb.pro
         run: |
           # Initial setup of dependencies
           pushd frontend


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/merge.yml` file to set environment variables for the frontend build jobs.

Environment variable additions:

* [`jobs:frontend-build-staging`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1R182-R183): Added `BASE_URL` environment variable with value `https://send.thunderbird.dev`
* [`jobs:frontend-build-prod`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1R236-R237): Added `BASE_URL` environment variable with value `https://send.tb.pro`