### PR TITLE
chore: bump frontend version to 0.1.40

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunderbird-send",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.1.39",
+  "version": "0.1.40",
   "author": "Thunderbird Team",
   "name": "Thunderbird Send",
   "description": "Thunderbird and friends",


### PR DESCRIPTION
This pull request includes a small version update for the `thunderbird-send` project. The version is incremented from `0.1.39` to `0.1.40` in both the `package.json` and `manifest.json` files.

* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L3-R3): Updated project version to `0.1.40`.
* [`frontend/public/manifest.json`](diffhunk://#diff-6b6b217f85b59e6b3d95585685a5b3c86eca800d97e2b00cfffd136c2604c234L3-R3): Updated project version to `0.1.40`.