### PR TITLE
Rename validate frontend job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,7 +119,7 @@ jobs:
           src: "./pulumi"
 
   # When the frontend code changes, run these steps
-  frontend-lint:
+  frontend-tests-and-lint:
     needs: detect-changes
     runs-on: ubuntu-latest
     env:
@@ -155,8 +155,8 @@ jobs:
           VITE_POSTHOG_HOST=${{ vars.VITE_POSTHOG_HOST }}
           EOF
 
-      - name: Frontend lint
-        id: frontend-lint
+      - name: Frontend tests and lint
+        id: frontend-tests-and-lint
         shell: bash
         run: |
           cd frontend


### PR DESCRIPTION
Update the GHA validate frontend job name to indicate it also runs the frontend tests as well as frontend linting, as it's not obvious in the PR checks where to find the frontend test results.