### PR TITLE
include package version on response

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
 
 type Environment = 'development' | 'production';
 export type EnvironmentName = 'stage' | 'prod' | 'development';
@@ -12,6 +14,12 @@ const appConfig = {
   // detect_base_url: false,
   max_file_size: 1024 * 1024 * 1024 * 2.5,
 };
+
+const packageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8')
+);
+
+export const VERSION = packageJson.version;
 
 const ENVIRONMENT = process.env.NODE_ENV || ('development' as Environment);
 const BASE_URL = process.env.BASE_URL;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ import * as Sentry from '@sentry/node';
 
 import { getDataFromAuthenticatedRequest } from './auth/client';
 import { errorHandler } from './errors/routes';
+import { addVersionHeader } from './middleware';
 import metricsRoute from './routes/metrics';
 import { containersRouter } from './trpc/containers';
 import { sharingRouter } from './trpc/sharing';
@@ -71,6 +72,7 @@ app.use((req, res, next) => {
 
 app.set('trust proxy', 1); // trust first proxy
 app.use(cookieParser());
+app.use(addVersionHeader);
 
 app.get('/', (_, res) => {
   res.status(200).send('echo');

--- a/backend/src/middleware.ts
+++ b/backend/src/middleware.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { getDataFromAuthenticatedRequest } from './auth/client';
 import { validateJWT } from './auth/jwt';
+import { VERSION } from './config';
 import { fromPrismaV2 } from './models/prisma-helper';
 import {
   allPermissions,
@@ -206,4 +207,14 @@ export function requirePublicLogin(
     return next();
   }
   return reject(res, 500, 'Public login is disabled');
+}
+
+// We add the package.json version to the response headers
+export function addVersionHeader(
+  _: Request,
+  res: Response,
+  next: NextFunction
+) {
+  res.setHeader('x-tbsend', VERSION);
+  next();
 }

--- a/backend/src/sentry.ts
+++ b/backend/src/sentry.ts
@@ -2,13 +2,7 @@
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import 'dotenv/config';
-import fs from 'fs';
-import path from 'path';
-import { ENVIRONMENT, getEnvironmentName } from './config';
-
-const packageJson = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8')
-);
+import { ENVIRONMENT, getEnvironmentName, VERSION } from './config';
 
 const TRACING_LEVELS_PROD = ['error', 'warn'];
 const TRACING_LEVELS_DEV = ['error', 'warn', 'debug'];
@@ -56,10 +50,10 @@ Sentry.init({
 
   // Set sampling rate for profiling - this is relative to tracesSampleRate
   profilesSampleRate: 1.0,
-  release: packageJson.version,
+  release: VERSION,
 });
 
 Sentry.setTag('environmentName', getEnvironmentName());
 
 console.log('Sentry initialized with env: ' + ENVIRONMENT);
-console.log('Sentry is using release version: ' + packageJson.version);
+console.log('Sentry is using release version: ' + VERSION);


### PR DESCRIPTION
This pull request introduces several changes to the backend configuration and middleware to include the application version from `package.json` in the response headers and Sentry initialization. The most important changes are summarized below:

### Middleware Updates:

* [`backend/src/middleware.ts`](diffhunk://#diff-2f835e968c8262238b6841d78c44a38da621e1b4ad12faf05d9d497d44252f16R6): Added a new middleware function `addVersionHeader` that sets the `x-tbsend` header to the application version. [[1]](diffhunk://#diff-2f835e968c8262238b6841d78c44a38da621e1b4ad12faf05d9d497d44252f16R6) [[2]](diffhunk://#diff-2f835e968c8262238b6841d78c44a38da621e1b4ad12faf05d9d497d44252f16R211-R220)

### Integration with Sentry:

* [`backend/src/sentry.ts`](diffhunk://#diff-22737fdd4565ba5f7b010cfaedb059c27a66ed8dec6121a10de03795f1dabeaaL5-R5): Updated the Sentry initialization to use the `VERSION` from `config.ts` instead of reading directly from `package.json`. [[1]](diffhunk://#diff-22737fdd4565ba5f7b010cfaedb059c27a66ed8dec6121a10de03795f1dabeaaL5-R5) [[2]](diffhunk://#diff-22737fdd4565ba5f7b010cfaedb059c27a66ed8dec6121a10de03795f1dabeaaL59-R59)

### Application Setup:

* [`backend/src/index.ts`](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R31): Imported the `addVersionHeader` middleware and applied it to the application. [[1]](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R31) [[2]](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R75)