### PR TITLE
Migrate userid and containerid to uuid

### DIFF
--- a/packages/send/backend/package.json
+++ b/packages/send/backend/package.json
@@ -26,7 +26,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "test": "vitest run --silent",
     "test:watch": "vitest --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch"
   },
   "lint-staged": {
     "*.{js,ts}": [
@@ -62,6 +63,7 @@
     "passport-openidconnect": "^0.1.2",
     "posthog-node": "^4.11.3",
     "prisma": "^5.22.0",
+    "uuid": "^11.1.0",
     "vite": ">=5.4.17",
     "websocket": "npm:ws@^8.18.1",
     "zod": "^3.24.2"

--- a/packages/send/backend/pnpm-lock.yaml
+++ b/packages/send/backend/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       prisma:
         specifier: ^5.22.0
         version: 5.22.0
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vite:
         specifier: '>=5.4.17'
         version: 6.2.6(@types/node@22.13.14)(yaml@2.7.1)
@@ -3059,6 +3062,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -6636,6 +6643,8 @@ snapshots:
       punycode: 2.3.1
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 

--- a/packages/send/backend/prisma/migrations/20250415165830_add_hash_password/migration.sql
+++ b/packages/send/backend/prisma/migrations/20250415165830_add_hash_password/migration.sql
@@ -1,0 +1,70 @@
+/*
+  Warnings:
+
+  - The primary key for the `Membership` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Container" DROP CONSTRAINT "Container_ownerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Invitation" DROP CONSTRAINT "Invitation_recipientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Profile" DROP CONSTRAINT "Profile_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Share" DROP CONSTRAINT "Share_senderId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Upload" DROP CONSTRAINT "Upload_ownerId_fkey";
+
+-- AlterTable
+ALTER TABLE "Container" ALTER COLUMN "ownerId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Invitation" ALTER COLUMN "recipientId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_pkey",
+ALTER COLUMN "userId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "Membership_pkey" PRIMARY KEY ("groupId", "userId");
+
+-- AlterTable
+ALTER TABLE "Profile" ALTER COLUMN "userId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Share" ALTER COLUMN "senderId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Upload" ALTER COLUMN "ownerId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+ADD COLUMN     "hashedPassword" TEXT,
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "User_id_seq";
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Share" ADD CONSTRAINT "Share_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Container" ADD CONSTRAINT "Container_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Upload" ADD CONSTRAINT "Upload_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/send/backend/prisma/migrations/20250415170530_uuid_for_users_and_containers/migration.sql
+++ b/packages/send/backend/prisma/migrations/20250415170530_uuid_for_users_and_containers/migration.sql
@@ -1,0 +1,54 @@
+/*
+  Warnings:
+
+  - The primary key for the `Container` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[id]` on the table `Container` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Container" DROP CONSTRAINT "Container_parentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Item" DROP CONSTRAINT "Item_containerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Share" DROP CONSTRAINT "Share_containerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_ContainerToTag" DROP CONSTRAINT "_ContainerToTag_A_fkey";
+
+-- AlterTable
+ALTER TABLE "Container" DROP CONSTRAINT "Container_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "parentId" SET DATA TYPE TEXT,
+ADD CONSTRAINT "Container_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "Container_id_seq";
+
+-- AlterTable
+ALTER TABLE "Item" ALTER COLUMN "containerId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Share" ALTER COLUMN "containerId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "_ContainerToTag" ALTER COLUMN "A" SET DATA TYPE TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Container_id_key" ON "Container"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_id_key" ON "User"("id");
+
+-- AddForeignKey
+ALTER TABLE "Share" ADD CONSTRAINT "Share_containerId_fkey" FOREIGN KEY ("containerId") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Container" ADD CONSTRAINT "Container_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Container"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_containerId_fkey" FOREIGN KEY ("containerId") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ContainerToTag" ADD CONSTRAINT "_ContainerToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/send/backend/prisma/migrations/20250416192322_use_uuid_types/migration.sql
+++ b/packages/send/backend/prisma/migrations/20250416192322_use_uuid_types/migration.sql
@@ -1,0 +1,156 @@
+/*
+  Warnings:
+
+  - The primary key for the `Container` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `parentId` column on the `Container` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `Membership` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `id` on the `Container` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `ownerId` on the `Container` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `recipientId` on the `Invitation` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `containerId` on the `Item` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `uploadId` on the `Item` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `userId` on the `Membership` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `userId` on the `Profile` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `containerId` on the `Share` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `senderId` on the `Share` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `id` on the `Upload` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `ownerId` on the `Upload` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `id` on the `User` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `A` on the `_ContainerToTag` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Container" DROP CONSTRAINT "Container_ownerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Container" DROP CONSTRAINT "Container_parentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Invitation" DROP CONSTRAINT "Invitation_recipientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Item" DROP CONSTRAINT "Item_containerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Item" DROP CONSTRAINT "Item_uploadId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Profile" DROP CONSTRAINT "Profile_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Share" DROP CONSTRAINT "Share_containerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Share" DROP CONSTRAINT "Share_senderId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Upload" DROP CONSTRAINT "Upload_ownerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_ContainerToTag" DROP CONSTRAINT "_ContainerToTag_A_fkey";
+
+-- DropIndex
+DROP INDEX "Upload_id_key";
+
+-- AlterTable
+ALTER TABLE "Container" DROP CONSTRAINT "Container_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL,
+DROP COLUMN "ownerId",
+ADD COLUMN     "ownerId" UUID NOT NULL,
+DROP COLUMN "parentId",
+ADD COLUMN     "parentId" UUID,
+ADD CONSTRAINT "Container_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "Invitation" DROP COLUMN "recipientId",
+ADD COLUMN     "recipientId" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Item" DROP COLUMN "containerId",
+ADD COLUMN     "containerId" UUID NOT NULL,
+DROP COLUMN "uploadId",
+ADD COLUMN     "uploadId" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_pkey",
+DROP COLUMN "userId",
+ADD COLUMN     "userId" UUID NOT NULL,
+ADD CONSTRAINT "Membership_pkey" PRIMARY KEY ("groupId", "userId");
+
+-- AlterTable
+ALTER TABLE "Profile" DROP COLUMN "userId",
+ADD COLUMN     "userId" UUID NOT NULL,
+ADD CONSTRAINT "Profile_pkey" PRIMARY KEY ("userId");
+
+-- AlterTable
+ALTER TABLE "Share" DROP COLUMN "containerId",
+ADD COLUMN     "containerId" UUID NOT NULL,
+DROP COLUMN "senderId",
+ADD COLUMN     "senderId" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Upload" DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL,
+DROP COLUMN "ownerId",
+ADD COLUMN     "ownerId" UUID NOT NULL,
+ADD CONSTRAINT "Upload_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" UUID NOT NULL,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "_ContainerToTag" DROP COLUMN "A",
+ADD COLUMN     "A" UUID NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Container_id_key" ON "Container"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_id_key" ON "User"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ContainerToTag_AB_unique" ON "_ContainerToTag"("A", "B");
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Share" ADD CONSTRAINT "Share_containerId_fkey" FOREIGN KEY ("containerId") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Share" ADD CONSTRAINT "Share_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Container" ADD CONSTRAINT "Container_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Container" ADD CONSTRAINT "Container_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Container"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_containerId_fkey" FOREIGN KEY ("containerId") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_uploadId_fkey" FOREIGN KEY ("uploadId") REFERENCES "Upload"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Upload" ADD CONSTRAINT "Upload_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ContainerToTag" ADD CONSTRAINT "_ContainerToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Container"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/send/backend/prisma/schema.prisma
+++ b/packages/send/backend/prisma/schema.prisma
@@ -20,7 +20,7 @@ enum UserTier {
 }
 
 model User {
-  id                  String               @id @default(uuid()) @unique
+  id                  String               @id @default(uuid()) @unique @db.Uuid
   email               String?
   publicKey           String?
   tier                UserTier
@@ -33,7 +33,6 @@ model User {
 
   profile             Profile?
 
-  // links            Link[]
   uploads             Upload[]
   groups              Membership[]
   containers          Container[]
@@ -43,7 +42,6 @@ model User {
 
   // Invitations sent to this user
   invitations         Invitation[]         @relation("Recipient")
-  // ephemeralLinks      EphemeralLink[] @relation("Ephemeral")
 
   backupKeypair       String?
   backupContainerKeys String?
@@ -58,7 +56,7 @@ model Profile {
 
   // 1-1 relationship with User
   user          User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId        String     @unique
+  userId        String @id @default(uuid()) @unique @db.Uuid
 
   accessToken   String?
   refreshToken  String?
@@ -74,8 +72,8 @@ model Group {
 model Membership {
   groupId     Int
   group       Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  userId      String
-  user        User  @relation(fields: [userId], references: [id])
+  userId      String @db.Uuid
+  user        User  @relation(fields: [userId], references: [id]) 
   permission  Int   @default(0)
                     // Modeled as a bitfield, i.e., 0b00000110
                     // See src/types/custom.ts for values
@@ -90,12 +88,12 @@ model Membership {
 // for a Container.
 // See the PermissionType enum in src/types/custom.ts
 model Share {
-  id              Int     @id @default(autoincrement())
-  containerId     String
+  id              Int       @id @default(autoincrement())
+  containerId     String    @db.Uuid
   container       Container @relation("SharedFolder", fields: [containerId], references: [id], onDelete: Cascade)
 
-  senderId        String   // Not necessarily the owner of the container
-  sender          User    @relation("Sender", fields: [senderId], references: [id])
+  senderId        String    @db.Uuid
+  sender          User      @relation("Sender", fields: [senderId], references: [id])
 
   // There are two ways to access a Share.
   // A User can accept an Invitation.
@@ -118,7 +116,7 @@ model Invitation {
   share         Share   @relation(fields: [shareId], references: [id], onDelete: Cascade)
   wrappedKey    String  // Container key wrapped with recipient publicKey
 
-  recipientId   String
+  recipientId   String  @db.Uuid
   recipient     User    @relation("Recipient", fields: [recipientId], references: [id])
   status        InvitationStatus @default(PENDING)
 
@@ -170,7 +168,7 @@ enum ContainerType {
 }
 
 model Container {
-  id        String            @id @default(uuid()) @unique
+  id        String            @id @default(uuid()) @unique @db.Uuid
   name      String
   createdAt DateTime?
   updatedAt DateTime?
@@ -179,13 +177,13 @@ model Container {
   shareOnly Boolean         @default(false)
   shares    Share[]         @relation("SharedFolder")
 
-  ownerId   String
+  ownerId   String          @db.Uuid
   owner     User            @relation(fields: [ownerId], references: [id])
   groupId   Int             @unique
   group     Group           @relation(fields: [groupId], references: [id], onDelete: Cascade)
   items     Item[]
   wrappedKey  String? // this container's key, wrapped using the parent's key
-  parentId  String?
+  parentId  String?         @db.Uuid
   parent    Container?      @relation("Nesting", fields: [parentId], references: [id])
   children  Container[]     @relation("Nesting")
 
@@ -201,30 +199,23 @@ model Item {
   id            Int           @id @default(autoincrement())
   name          String
   wrappedKey    String
-  containerId   String
+  containerId   String        @db.Uuid
   container     Container     @relation(fields: [containerId], references: [id], onDelete: Cascade)
-  uploadId      String
+  uploadId      String        @db.Uuid
   // Do not cascade, since uploads can exist in different Containers as
   // different Items
-  upload        Upload          @relation(fields: [uploadId], references: [id] )
+  upload        Upload        @relation(fields: [uploadId], references: [id] )
   type          ItemType
   createdAt     DateTime?
-  updatedAt     DateTime?
-  // unique "file names" in a container
-  // @@unique([name, containerId])
-
-  // You could make threads by uncommenting the following:
-  // parentId  Int?
-  // parent    Item?      @relation("Nesting", fields: [parentId], references: [id])
-  // children  Item[]     @relation("Nesting")
+  updatedAt     DateTime? 
 
   tags      Tag[]
 }
 
 model Upload {
-  id        String        @id @default(uuid())
+  id        String        @id @default(uuid()) @db.Uuid
   size      Int
-  ownerId   String
+  ownerId   String        @db.Uuid
   owner     User          @relation(fields: [ownerId], references: [id])
   items     Item[]        // A single Upload may back multiple Items
   type      String        // mime type

--- a/packages/send/backend/prisma/schema.prisma
+++ b/packages/send/backend/prisma/schema.prisma
@@ -20,7 +20,7 @@ enum UserTier {
 }
 
 model User {
-  id                  Int                  @id @default(autoincrement())
+  id                  String               @id @default(uuid()) @unique
   email               String?
   publicKey           String?
   tier                UserTier
@@ -58,7 +58,7 @@ model Profile {
 
   // 1-1 relationship with User
   user          User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId        Int     @unique
+  userId        String     @unique
 
   accessToken   String?
   refreshToken  String?
@@ -74,7 +74,7 @@ model Group {
 model Membership {
   groupId     Int
   group       Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  userId      Int
+  userId      String
   user        User  @relation(fields: [userId], references: [id])
   permission  Int   @default(0)
                     // Modeled as a bitfield, i.e., 0b00000110
@@ -91,10 +91,10 @@ model Membership {
 // See the PermissionType enum in src/types/custom.ts
 model Share {
   id              Int     @id @default(autoincrement())
-  containerId     Int
+  containerId     String
   container       Container @relation("SharedFolder", fields: [containerId], references: [id], onDelete: Cascade)
 
-  senderId        Int   // Not necessarily the owner of the container
+  senderId        String   // Not necessarily the owner of the container
   sender          User    @relation("Sender", fields: [senderId], references: [id])
 
   // There are two ways to access a Share.
@@ -118,7 +118,7 @@ model Invitation {
   share         Share   @relation(fields: [shareId], references: [id], onDelete: Cascade)
   wrappedKey    String  // Container key wrapped with recipient publicKey
 
-  recipientId   Int
+  recipientId   String
   recipient     User    @relation("Recipient", fields: [recipientId], references: [id])
   status        InvitationStatus @default(PENDING)
 
@@ -170,7 +170,7 @@ enum ContainerType {
 }
 
 model Container {
-  id        Int             @id @default(autoincrement())
+  id        String            @id @default(uuid()) @unique
   name      String
   createdAt DateTime?
   updatedAt DateTime?
@@ -179,13 +179,13 @@ model Container {
   shareOnly Boolean         @default(false)
   shares    Share[]         @relation("SharedFolder")
 
-  ownerId   Int
+  ownerId   String
   owner     User            @relation(fields: [ownerId], references: [id])
   groupId   Int             @unique
   group     Group           @relation(fields: [groupId], references: [id], onDelete: Cascade)
   items     Item[]
   wrappedKey  String? // this container's key, wrapped using the parent's key
-  parentId  Int?
+  parentId  String?
   parent    Container?      @relation("Nesting", fields: [parentId], references: [id])
   children  Container[]     @relation("Nesting")
 
@@ -201,7 +201,7 @@ model Item {
   id            Int           @id @default(autoincrement())
   name          String
   wrappedKey    String
-  containerId   Int
+  containerId   String
   container     Container     @relation(fields: [containerId], references: [id], onDelete: Cascade)
   uploadId      String
   // Do not cascade, since uploads can exist in different Containers as
@@ -222,9 +222,9 @@ model Item {
 }
 
 model Upload {
-  id        String        @unique
+  id        String        @id @default(uuid())
   size      Int
-  ownerId   Int
+  ownerId   String
   owner     User          @relation(fields: [ownerId], references: [id])
   items     Item[]        // A single Upload may back multiple Items
   type      String        // mime type

--- a/packages/send/backend/src/auth/jwt.ts
+++ b/packages/send/backend/src/auth/jwt.ts
@@ -9,7 +9,7 @@ type Args = {
 /**
  * The output is either 'valid' or 'shouldRefresh' or null. No other string is possible.
  **/
-type ValidationResult = 'valid' | 'shouldRefresh' | null;
+type ValidationResult = 'valid' | 'shouldRefresh' | 'shouldLogin' | null;
 
 /**
  * This function validates the JWT token and returns a string indicating whether the token is valid or not.
@@ -29,12 +29,19 @@ export const validateJWT = ({
     return null;
   }
 
+  // validate refresh token
+  try {
+    jwt.verify(refreshToken, process.env.REFRESH_TOKEN_SECRET);
+  } catch {
+    // Refresh token failed to verify, tell the user to re-login.
+    return 'shouldLogin';
+  }
+  // validate access token
   try {
     jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-    return 'valid';
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // catch error and try to refresh token
     return 'shouldRefresh';
   }
+  return 'valid';
 };

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -74,6 +74,15 @@ export async function requireJWT(
     return next();
   }
 
+  // When refresh token is invalid, we should return 403 and ask to login
+  if (validationResult === 'shouldLogin') {
+    return res.status(403).json({
+      message: `Not authorized: Refresh token expired`,
+    });
+  }
+
+  // When the refresh token is valid but the token is not, we should return 401
+  // this is handled as autoretry in the client
   if (validationResult === 'shouldRefresh') {
     return res.status(401).json({
       message: `Not authorized: Token expired`,

--- a/packages/send/backend/src/middleware.ts
+++ b/packages/send/backend/src/middleware.ts
@@ -25,11 +25,11 @@ function extractParamOrBody(req, prop: string) {
   return req.params[prop] ?? req.body[prop];
 }
 
-function extractContainerId(req) {
+function extractContainerId(req): string {
   const prop = `containerId`;
   const val = extractParamOrBody(req, prop);
   try {
-    return parseInt(val, 10);
+    return val;
   } catch (e) {
     console.error(
       `Could not find ${prop} for ${extractMethodAndRoute(req)}`,
@@ -113,7 +113,7 @@ export const getGroupMemberPermissions: RequestHandler = async (
   const { id: userId } = getDataFromAuthenticatedRequest(req);
   const containerId = extractContainerId(req);
 
-  if (userId && containerId === 0) {
+  if (userId) {
     // Users have full permissions to their own top-level
     console.log(`
 *************************************************************************************

--- a/packages/send/backend/src/models.ts
+++ b/packages/send/backend/src/models.ts
@@ -27,10 +27,7 @@ import { fromPrismaV2, fromPrismaV3 } from './models/prisma-helper';
 import { PermissionType } from './types/custom';
 const prisma = new PrismaClient();
 
-export async function getSharesForContainer(
-  containerId: number
-  // userId: number
-) {
+export async function getSharesForContainer(containerId: string) {
   const query = {
     where: {
       containerId,
@@ -70,9 +67,9 @@ export async function updateItemName(itemId: number, name: string) {
 }
 
 export async function updateInvitationPermissions(
-  containerId: number,
+  containerId: string,
   invitationId: number,
-  userId: number,
+  userId: string,
   permission: PermissionType
 ) {
   const query = {
@@ -92,9 +89,9 @@ export async function updateInvitationPermissions(
 }
 
 export async function updateAccessLinkPermissions(
-  containerId: number,
+  containerId: string,
   accessLinkId: string,
-  userId: number,
+  userId: string,
   permission: PermissionType
 ) {
   const query = {
@@ -113,7 +110,7 @@ export async function updateAccessLinkPermissions(
   );
 }
 
-export async function getContainerWithMembers(containerId: number) {
+export async function getContainerWithMembers(containerId: string) {
   const query = {
     where: {
       id: containerId,
@@ -158,7 +155,7 @@ export async function reportUpload(uploadId: string) {
 
 export async function createItem(
   name: string,
-  containerId: number,
+  containerId: string,
   uploadId: string,
   type: ItemType,
   wrappedKey: string
@@ -251,7 +248,7 @@ export async function deleteItem(id: number, shouldDeleteUpload = false) {
   return result;
 }
 
-export async function getContainerInfo(id: number) {
+export async function getContainerInfo(id: string) {
   const query = {
     where: {
       id,
@@ -264,7 +261,7 @@ export async function getContainerInfo(id: number) {
   );
 }
 
-export async function getUploadsOwnedByUser(id: number) {
+export async function getUploadsOwnedByUser(id: string) {
   return await prisma.upload.findMany({
     where: {
       ownerId: id,
@@ -283,7 +280,7 @@ export async function deleteUpload(id: string) {
   });
 }
 
-export async function getContainersOwnedByUser(id: number) {
+export async function getContainersOwnedByUser(id: string) {
   return await prisma.container.findMany({
     where: {
       ownerId: id,
@@ -295,11 +292,11 @@ export async function getContainersOwnedByUser(id: number) {
   });
 }
 
-export async function deleteContainer(id: number) {
+export async function deleteContainer(id: string) {
   return prisma.container.delete({ where: { id } });
 }
 
-export async function getContainerWithDescendants(id: number) {
+export async function getContainerWithDescendants(id: string) {
   const query = {
     where: { id },
     include: {
@@ -325,7 +322,7 @@ export async function getContainerWithDescendants(id: number) {
   return container;
 }
 
-export async function addGroupMember(containerId: number, userId: number) {
+export async function addGroupMember(containerId: string, userId: string) {
   const findContainerQuery = {
     where: {
       id: containerId,
@@ -417,7 +414,7 @@ export async function removeInvitationAndGroup(invitationId: number) {
   );
 }
 
-export async function removeGroupMember(containerId: number, userId: number) {
+export async function removeGroupMember(containerId: string, userId: string) {
   const findGroupQuery = {
     where: {
       container: {
@@ -479,7 +476,7 @@ export async function createTagForItem(
 export async function createTagForContainer(
   tagName: string,
   color: string,
-  containerId: number
+  containerId: string
 ) {
   // trim, but don't normalize the case
   const name = tagName.trim();
@@ -534,7 +531,7 @@ export async function updateTagName(tagId: number, name: string) {
 // Get all items and containers (that I have access to) with a specific tag or tags
 
 export async function getContainersAndItemsWithTags(
-  userId: number,
+  userId: string,
   tagNames: string[]
 ) {
   // First, find the group memberships for the user.

--- a/packages/send/backend/src/models/containers.ts
+++ b/packages/send/backend/src/models/containers.ts
@@ -18,9 +18,9 @@ const prisma = new PrismaClient();
 // owner is added to new group
 export async function createContainer(
   name: string,
-  ownerId: number,
+  ownerId: string,
   type: ContainerType,
-  parentId: number,
+  parentId: string | null,
   shareOnly: boolean
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,7 +53,7 @@ export async function createContainer(
       updatedAt: new Date(),
     },
   };
-  if (parentId !== 0) {
+  if (parentId) {
     query.data['parentId'] = parentId;
   }
 
@@ -64,7 +64,7 @@ export async function createContainer(
   );
 }
 
-export async function getItemsInContainer(id: number) {
+export async function getItemsInContainer(id: string) {
   // Nested include syntax
   // per https://github.com/prisma/prisma/discussions/5810#discussioncomment-400341
 
@@ -85,7 +85,7 @@ export async function getItemsInContainer(id: number) {
   );
 }
 
-export async function getContainerWithAncestors(id: number) {
+export async function getContainerWithAncestors(id: string) {
   const query = {
     where: {
       id,
@@ -104,7 +104,7 @@ export async function getContainerWithAncestors(id: number) {
   return container;
 }
 
-export async function getAccessLinksForContainer(containerId: number) {
+export async function getAccessLinksForContainer(containerId: string) {
   const shares = await fromPrismaV2(prisma.share.findMany, {
     where: {
       containerId,
@@ -130,7 +130,7 @@ export async function getAccessLinksForContainer(containerId: number) {
   );
 }
 
-export async function updateContainerName(containerId: number, name: string) {
+export async function updateContainerName(containerId: string, name: string) {
   const query = {
     where: {
       id: containerId,

--- a/packages/send/backend/src/models/sharing.ts
+++ b/packages/send/backend/src/models/sharing.ts
@@ -48,8 +48,8 @@ const onCreateError = () => {
  * Function will throw an error if unable to create the new share or the access link.
  */
 export async function createAccessLink(
-  containerId: number,
-  senderId: number,
+  containerId: string,
+  senderId: string,
   wrappedKey: string,
   salt: string,
   challengeKey: string,
@@ -280,10 +280,10 @@ export async function getContainerForAccessLink(linkId: string) {
  * TODO: Need to specify which share, in case there are multiple?
  */
 export async function createInvitation(
-  containerId: number,
+  containerId: string,
   wrappedKey: string,
-  senderId: number,
-  recipientId: number,
+  senderId: string,
+  recipientId: string,
   permission: number
 ) {
   let share: Share;
@@ -352,7 +352,7 @@ export async function createInvitation(
 
 export async function createInvitationFromAccessLink(
   linkId: string,
-  recipientId: number
+  recipientId: string
 ) {
   const findAccessLinkQuery = {
     where: {
@@ -436,7 +436,7 @@ export async function removeAccessLink(linkId: string) {
   );
 }
 
-export async function getAllInvitations(userId: number) {
+export async function getAllInvitations(userId: string) {
   const query = {
     where: {
       recipientId: userId,
@@ -511,7 +511,7 @@ export async function acceptInvitation(invitationId: number) {
 }
 
 export async function getContainersSharedByUser(
-  userId: number
+  userId: string
   // _type: ContainerType
 ) {
   const query = {
@@ -565,7 +565,7 @@ export async function getContainersSharedByUser(
 }
 
 export async function getContainersSharedWithUser(
-  recipientId: number,
+  recipientId: string,
   type: ContainerType
 ) {
   const query = {
@@ -592,7 +592,7 @@ export async function getContainersSharedWithUser(
 }
 
 export async function burnFolder(
-  containerId: number,
+  containerId: string,
   shouldDeleteUpload?: boolean
 ) {
   // delete the ephemeral link
@@ -768,6 +768,6 @@ export async function burnFolder(
   };
 }
 
-export async function burnEphemeralConversation(containerId: number) {
+export async function burnEphemeralConversation(containerId: string) {
   return await burnFolder(containerId);
 }

--- a/packages/send/backend/src/models/uploads.ts
+++ b/packages/send/backend/src/models/uploads.ts
@@ -13,7 +13,7 @@ import {
 export async function createUpload(
   id: string,
   size: number,
-  ownerId: number,
+  ownerId: string,
   type: string
 ) {
   // Confirm that file `id` exists and what's on disk

--- a/packages/send/backend/src/models/users.ts
+++ b/packages/send/backend/src/models/users.ts
@@ -24,11 +24,11 @@ export async function createUser(
   });
 }
 
-export async function getUserById(id: number) {
+export async function getUserById(id: string) {
   return await prisma.user.findUnique({ where: { id } });
 }
 
-export async function resetKeys(id: number) {
+export async function resetKeys(id: string) {
   return await prisma.user.update({
     data: {
       publicKey: null,
@@ -181,7 +181,7 @@ export async function findOrCreateUserProfileByMozillaId(
   return user;
 }
 
-export async function getUserPublicKey(id: number) {
+export async function getUserPublicKey(id: string) {
   const query = {
     where: {
       id,
@@ -198,7 +198,7 @@ export async function getUserPublicKey(id: number) {
   );
 }
 
-export async function updateUserPublicKey(id: number, publicKey: string) {
+export async function updateUserPublicKey(id: string, publicKey: string) {
   const query = {
     where: {
       id,
@@ -211,12 +211,12 @@ export async function updateUserPublicKey(id: number, publicKey: string) {
   return await fromPrismaV2(prisma.user.update, query, USER_NOT_UPDATED);
 }
 
-export async function updateUniqueHash(id: number, uniqueHash: string) {
+export async function updateUniqueHash(id: string, uniqueHash: string) {
   await prisma.user.update({ where: { id }, data: { uniqueHash } });
 }
 
 async function _whereContainer(
-  userId: number,
+  userId: string,
   type: ContainerType | null,
   shareOnly?: boolean,
   topLevelOnly?: boolean
@@ -266,7 +266,7 @@ async function _whereContainer(
 
 // Does not include shareOnly containers.
 export async function getAllUserGroupContainers(
-  userId: number,
+  userId: string,
   type: ContainerType | null
 ) {
   const containerWhere = await _whereContainer(userId, type, false, true);
@@ -280,7 +280,7 @@ export async function getAllUserGroupContainers(
 }
 
 export async function getRecentActivity(
-  userId: number,
+  userId: string,
   type: ContainerType | null
 ) {
   // Get all containers
@@ -318,7 +318,7 @@ export async function getRecentActivity(
   return await fromPrisma(prisma.container.findMany as any, query);
 }
 
-export async function getBackup(id: number) {
+export async function getBackup(id: string) {
   const query = {
     where: {
       id,
@@ -339,7 +339,7 @@ export async function getBackup(id: number) {
 }
 
 export async function setBackup(
-  id: number,
+  id: string,
   keys: string,
   keypair: string,
   keystring: string,

--- a/packages/send/backend/src/routes/containers.ts
+++ b/packages/send/backend/src/routes/containers.ts
@@ -49,12 +49,12 @@ import { addExpiryToContainer } from '@/utils';
 
 const router: Router = Router();
 
-export type TreeNode = {
-  id: number;
-  children: TreeNode[] | [];
-};
+export interface TreeNode {
+  id: string;
+  children: TreeNode[];
+}
 
-export function flattenDescendants(tree: TreeNode): number[] {
+export function flattenDescendants(tree: TreeNode): string[] {
   if (!tree || !tree.id) {
     return [];
   }
@@ -95,7 +95,7 @@ router.get(
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
-    const container = await getItemsInContainer(parseInt(containerId));
+    const container = await getItemsInContainer(containerId);
     const { hasLimitedStorage } = getStorageLimit(req);
 
     if (!container) {
@@ -147,7 +147,7 @@ router.get(
   addErrorHandling(CONTAINER_ERRORS.ACCESS_LINKS_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
-    const links = await getAccessLinksForContainer(parseInt(containerId));
+    const links = await getAccessLinksForContainer(containerId);
     res.status(200).json(links);
   })
 );
@@ -208,10 +208,7 @@ router.post(
       shareOnly = req.body.shareOnly;
     }
 
-    let parentId = 0;
-    if (req.body.containerId) {
-      parentId = req.body.containerId;
-    }
+    const parentId = req.body.containerId;
 
     const container = await createContainer(
       name.trim().toLowerCase(),
@@ -266,7 +263,7 @@ router.post(
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
     const { name } = req.body;
-    const container = await updateContainerName(parseInt(containerId), name);
+    const container = await updateContainerName(containerId, name);
     res.status(200).json(container);
   })
 );
@@ -300,11 +297,11 @@ router.delete(
   addErrorHandling(CONTAINER_ERRORS.CONTAINER_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
-    const root = await getContainerWithDescendants(parseInt(containerId));
+    const root = await getContainerWithDescendants(containerId);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const idArray = flattenDescendants(root as any);
 
-    const burnPromises = idArray.map((id: number) =>
+    const burnPromises = idArray.map((id: string) =>
       burnFolder(id, true /* shouldDeleteUpload */)
     );
 
@@ -362,7 +359,7 @@ router.post(
     const { name, uploadId, type, wrappedKey } = req.body;
     const item = await createItem(
       name,
-      parseInt(containerId),
+      containerId,
       uploadId,
       type,
       wrappedKey
@@ -538,10 +535,10 @@ router.post(
       permission = req.body.permission;
     }
     const invitation = await createInvitation(
-      parseInt(containerId),
+      containerId,
       wrappedKey,
-      parseInt(senderId),
-      parseInt(recipientId),
+      senderId,
+      recipientId,
       parseInt(permission)
     );
     res.status(200).json(invitation);
@@ -621,10 +618,7 @@ router.post(
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
     const { userId } = req.body;
-    const container = await addGroupMember(
-      parseInt(containerId),
-      parseInt(userId)
-    );
+    const container = await addGroupMember(containerId, userId);
     res.status(200).json(container);
   })
 );
@@ -661,10 +655,7 @@ router.delete(
   addErrorHandling(CONTAINER_ERRORS.MEMBER_NOT_DELETED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId, userId } = req.params;
-    const container = await removeGroupMember(
-      parseInt(containerId),
-      parseInt(userId)
-    );
+    const container = await removeGroupMember(containerId, userId);
     res.status(200).json(container);
   })
 );
@@ -697,7 +688,7 @@ router.get(
   wrapAsyncHandler(async (req, res) => {
     // getContainerWithMembers
     const { containerId } = req.params;
-    const { group } = await getContainerWithMembers(parseInt(containerId));
+    const { group } = await getContainerWithMembers(containerId);
     res.status(200).json(group.members);
   })
 );
@@ -729,7 +720,7 @@ router.get(
   addErrorHandling(CONTAINER_ERRORS.INFO_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
-    const container = await getContainerInfo(parseInt(containerId));
+    const container = await getContainerInfo(containerId);
     res.status(200).json(container);
   })
 );
@@ -761,7 +752,7 @@ router.get(
   addErrorHandling(CONTAINER_ERRORS.SHARES_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
-    const result = await getSharesForContainer(parseInt(containerId));
+    const result = await getSharesForContainer(containerId);
     res.status(200).json({
       result,
     });
@@ -811,9 +802,9 @@ router.post(
     const { userId, invitationId, permission } = req.body; // TODO: get from session
 
     const result = await updateInvitationPermissions(
-      parseInt(containerId),
+      containerId,
       parseInt(invitationId),
-      parseInt(userId),
+      userId,
       parseInt(permission)
     );
     res.status(200).json({
@@ -864,9 +855,9 @@ router.post(
     const { containerId } = req.params;
     const { userId, accessLinkId, permission } = req.body; // TODO: get from session
     const result = await updateAccessLinkPermissions(
-      parseInt(containerId),
+      containerId,
       accessLinkId,
-      parseInt(userId),
+      userId,
       parseInt(permission)
     );
     res.status(200).json({

--- a/packages/send/backend/src/routes/sharing.ts
+++ b/packages/send/backend/src/routes/sharing.ts
@@ -78,8 +78,8 @@ router.post(
       challengePlaintext,
       expiration,
     }: {
-      containerId: number;
-      senderId: number;
+      containerId: string;
+      senderId: string;
       wrappedKey: string;
       salt: string;
       challengeKey: string;
@@ -295,7 +295,7 @@ router.post(
   addErrorHandling(SHARING_ERRORS.NOT_BURNED),
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.body;
-    const result = await burnEphemeralConversation(parseInt(containerId));
+    const result = await burnEphemeralConversation(containerId);
     res.status(200).json({
       result,
     });

--- a/packages/send/backend/src/routes/tags.ts
+++ b/packages/send/backend/src/routes/tags.ts
@@ -33,7 +33,7 @@ router.post(
   wrapAsyncHandler(async (req, res) => {
     const { containerId } = req.params;
     const { name, color } = req.body;
-    const tag = await createTagForContainer(name, color, parseInt(containerId));
+    const tag = await createTagForContainer(name, color, containerId);
     res.status(200).json(tag);
   })
 );

--- a/packages/send/backend/src/routes/users.ts
+++ b/packages/send/backend/src/routes/users.ts
@@ -99,8 +99,8 @@ router.get(
   requireJWT,
   addErrorHandling(USER_ERRORS.PUBLIC_KEY_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
-    const { id } = req.params;
-    const user = await getUserPublicKey(parseInt(id));
+    const { id } = getDataFromAuthenticatedRequest(req);
+    const user = await getUserPublicKey(id);
     res.status(200).json(user);
   })
 );
@@ -276,7 +276,7 @@ router.get(
   addErrorHandling(USER_ERRORS.FOLDERS_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
-    const containers = await getAllUserGroupContainers(parseInt(userId), null);
+    const containers = await getAllUserGroupContainers(userId, null);
     res.status(200).json(containers);
   })
 );
@@ -309,7 +309,7 @@ router.get(
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
     const containers = await getAllUserGroupContainers(
-      parseInt(userId),
+      userId,
       ContainerType.CONVERSATION
     );
     res.status(200).json(containers);
@@ -343,10 +343,7 @@ router.get(
   addErrorHandling(USER_ERRORS.HISTORY_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
-    const containers = await getRecentActivity(
-      parseInt(userId),
-      ContainerType.FOLDER
-    );
+    const containers = await getRecentActivity(userId, ContainerType.FOLDER);
     res.status(200).json(containers);
   })
 );
@@ -379,7 +376,7 @@ router.get(
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
     const containersAndMembers = await getContainersSharedByUser(
-      parseInt(userId)
+      userId
       /*
        * TODO: This functionality is incomplete. The previous functionality used this second parameter
        * We're keeping it to pick it up later.
@@ -419,7 +416,7 @@ router.get(
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
     const containersAndMembers = await getContainersSharedWithUser(
-      parseInt(userId),
+      userId,
       ContainerType.FOLDER
     );
 
@@ -454,7 +451,7 @@ router.get(
   addErrorHandling(USER_ERRORS.INVITATIONS_NOT_FOUND),
   wrapAsyncHandler(async (req, res) => {
     const { userId } = req.params;
-    const invitations = await getAllInvitations(parseInt(userId));
+    const invitations = await getAllInvitations(userId);
     res.status(200).json(invitations);
   })
 );
@@ -503,7 +500,7 @@ router.post(
     const { id } = req.params;
     const { keys, keypair, keystring, salt } = req.body;
     // We're not using the return value, but we want to make sure the backup runs
-    await setBackup(parseInt(id), keys, keypair, keystring, salt);
+    await setBackup(id, keys, keypair, keystring, salt);
     res.status(200).json({
       message: 'backup complete',
     });

--- a/packages/send/backend/src/test/auth/jwt.test.ts
+++ b/packages/send/backend/src/test/auth/jwt.test.ts
@@ -44,10 +44,13 @@ describe('validateJWT', () => {
   });
 
   it('should return shouldRefresh when token verification fails', () => {
-    vi.mocked(getJWTfromToken).mockReturnValue('invalid-token');
-    vi.mocked(jwt.verify).mockImplementation(() => {
-      throw new Error('Token invalid');
-    });
+    vi.resetAllMocks();
+    vi.mocked(getJWTfromToken).mockReturnValue('valid-token');
+    vi.mocked(jwt.verify)
+      .mockImplementationOnce(() => ({}) as never) // first call succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('Token invalid');
+      }); // second call throws
 
     const result = validateJWT({
       jwtToken: 'invalid-token',
@@ -55,5 +58,19 @@ describe('validateJWT', () => {
     });
 
     expect(result).toBe('shouldRefresh');
+  });
+
+  it('should return null when refresh token is not valid', () => {
+    vi.mocked(getJWTfromToken).mockReturnValue('invalid-refresh-token');
+    vi.mocked(jwt.verify).mockImplementation(() => {
+      throw new Error('Token invalid');
+    });
+
+    const result = validateJWT({
+      jwtToken: 'valid-token',
+      jwtRefreshToken: 'invalid-refresh-token',
+    });
+
+    expect(result).toBe('shouldLogin');
   });
 });

--- a/packages/send/backend/src/test/middleware.test.ts
+++ b/packages/send/backend/src/test/middleware.test.ts
@@ -64,14 +64,16 @@ describe('requireJWT', () => {
     });
   });
 
-  it('should reject with a status 401 if token is invalid', async () => {
+  it('should reject with a status 401 if the token is invalid', async () => {
     const token = 'invalid.token';
-    const refreshToken = 'invalid.refresh';
+    const refreshToken = 'valid.refresh';
     mockRequest.headers.cookie = `authorization=Bearer%20${token};refresh_token=Bearer%20${refreshToken}`;
 
-    vi.mocked(mockedVerify).mockImplementation((token, secret, callback) =>
-      callback(new Error('Invalid token'), null)
-    );
+    vi.mocked(mockedVerify).mockImplementation((token, secret, callback) => {
+      if (token === 'invalid.token') {
+        callback(new Error('Invalid token'), null);
+      }
+    });
 
     await requireJWT(
       mockRequest as Request,
@@ -82,6 +84,28 @@ describe('requireJWT', () => {
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toBeCalledWith({
       message: `Not authorized: Token expired`,
+    });
+    expect(mockedVerify).toHaveBeenCalled();
+  });
+
+  it('should reject with a status 403 if refresh token is invalid', async () => {
+    const token = 'invalid.token';
+    const refreshToken = 'valid.refresh';
+    mockRequest.headers.cookie = `authorization=Bearer%20${token};refresh_token=Bearer%20${refreshToken}`;
+
+    vi.mocked(mockedVerify).mockImplementationOnce((token, secret, callback) =>
+      callback(new Error('Invalid token'), null)
+    );
+
+    await requireJWT(
+      mockRequest as Request,
+      mockResponse as Response,
+      nextFunction
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+    expect(mockResponse.json).toBeCalledWith({
+      message: `Not authorized: Refresh token expired`,
     });
     expect(mockedVerify).toHaveBeenCalled();
   });

--- a/packages/send/backend/src/test/routes/containers.test.ts
+++ b/packages/send/backend/src/test/routes/containers.test.ts
@@ -2,15 +2,15 @@ import { flattenDescendants, TreeNode } from '@/routes/containers';
 import { describe, expect, it } from 'vitest';
 
 const containerNoChild: TreeNode = {
-  id: 1,
+  id: '1',
   children: [],
 };
 const containerWithChild: TreeNode = {
-  id: 2,
+  id: '2',
   children: [containerNoChild],
 };
 const containerWithGrandChild: TreeNode = {
-  id: 3,
+  id: '3',
   children: [containerWithChild],
 };
 
@@ -26,38 +26,42 @@ describe('flattenDescendants', () => {
   });
 
   it('should return grandchildren, children and root', () => {
-    expect(flattenDescendants(containerWithGrandChild)).toEqual([1, 2, 3]);
+    expect(flattenDescendants(containerWithGrandChild)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
   });
 
   it('should handle a tree with no children', () => {
-    expect(flattenDescendants(containerNoChild)).toEqual([1]);
+    expect(flattenDescendants(containerNoChild)).toEqual(['1']);
   });
 
   it('should flatten a tree with multiple children', () => {
     const tree: TreeNode = {
-      id: 1,
+      id: '1',
       children: [
-        { id: 2, children: [] },
-        { id: 3, children: [] },
+        { id: '2', children: [] },
+        { id: '3', children: [] },
       ],
     };
-    expect(flattenDescendants(tree)).toEqual([2, 3, 1]);
+    expect(flattenDescendants(tree)).toEqual(['2', '3', '1']);
   });
 
   it('should flatten a deeply nested tree', () => {
     const tree: TreeNode = {
-      id: 1,
+      id: '1',
       children: [
         {
-          id: 2,
+          id: '2',
           children: [
-            { id: 4, children: [] },
-            { id: 5, children: [] },
+            { id: '4', children: [] },
+            { id: '5', children: [] },
           ],
         },
-        { id: 3, children: [] },
+        { id: '3', children: [] },
       ],
     };
-    expect(flattenDescendants(tree)).toEqual([4, 5, 2, 3, 1]);
+    expect(flattenDescendants(tree)).toEqual(['4', '5', '2', '3', '1']);
   });
 });

--- a/packages/send/backend/src/test/trpc/middlewares.test.ts
+++ b/packages/send/backend/src/test/trpc/middlewares.test.ts
@@ -41,6 +41,15 @@ describe('Middleware tests', () => {
       );
     });
 
+    it('should throw FORBIDDEN error when token needs refresh', async () => {
+      vi.mocked(jwt.validateJWT).mockReturnValue('shouldLogin');
+
+      //@ts-ignore
+      await expect(isAuthed({ ctx: mockCtx, next: mockNext })).rejects.toThrow(
+        new TRPCError({ code: 'FORBIDDEN' })
+      );
+    });
+
     it('should throw FORBIDDEN error when validation fails', async () => {
       vi.mocked(jwt.validateJWT).mockReturnValue(null);
 

--- a/packages/send/backend/src/test/utils/index.test.ts
+++ b/packages/send/backend/src/test/utils/index.test.ts
@@ -76,9 +76,9 @@ describe('addExpiryToContainer', () => {
 
   it('should calculate correct days to expiry for a new upload', () => {
     const mockUpload: Upload = {
-      id: '1',
+      id: '123e4567-e89b-12d3-a456-426614174000',
       createdAt: new Date('2024-01-01'), // 14 days ago
-      ownerId: 1,
+      ownerId: 'user-123',
       reported: false,
       reportedAt: null,
       size: 100,
@@ -92,9 +92,9 @@ describe('addExpiryToContainer', () => {
 
   it('should mark as expired when exactly at expiry date', () => {
     const mockUpload: Upload = {
-      id: '1',
+      id: '123e4567-e89b-12d3-a456-426614174001',
       createdAt: new Date('2023-12-31'), // 15 days ago
-      ownerId: 1,
+      ownerId: 'user-123',
       reported: false,
       reportedAt: null,
       size: 100,
@@ -108,9 +108,9 @@ describe('addExpiryToContainer', () => {
 
   it('should mark as expired when past expiry date', () => {
     const mockUpload: Upload = {
-      id: '1',
+      id: '123e4567-e89b-12d3-a456-426614174002',
       createdAt: new Date('2023-12-30'), // 16 days ago
-      ownerId: 1,
+      ownerId: 'user-123',
       reported: false,
       reportedAt: null,
       size: 100,
@@ -146,10 +146,9 @@ describe('addExpiryToContainer', () => {
 
   it('should include days to expiry', () => {
     const mockUpload: Upload = {
-      id: '1',
-      // createdAt: new Date(Date.now() - 2 * TIME_CONSTANTS.MILLISECONDS_PER_DAY),
+      id: '123e4567-e89b-12d3-a456-426614174003',
       createdAt: new Date('2024-01-13'), // 2 days ago
-      ownerId: 1,
+      ownerId: 'user-123',
       reported: false,
       reportedAt: null,
       size: 100,

--- a/packages/send/backend/src/trpc/containers.ts
+++ b/packages/send/backend/src/trpc/containers.ts
@@ -45,7 +45,7 @@ export const containersRouter = router({
     };
 
     try {
-      const userId = Number(ctx.user.id);
+      const userId = ctx.user.id;
       const folders = await getAllUserGroupContainers(
         userId,
         ContainerType.FOLDER
@@ -124,7 +124,7 @@ export const containersRouter = router({
    */
   getAccessLinksForContainer: t
     .use(isAuthed)
-    .input(z.object({ containerId: z.number() }))
+    .input(z.object({ containerId: z.string() }))
     .query(async ({ input }) => {
       const accessLinks = await getAccessLinks(input.containerId);
       return accessLinks;

--- a/packages/send/backend/src/trpc/middlewares.ts
+++ b/packages/send/backend/src/trpc/middlewares.ts
@@ -33,7 +33,8 @@ export async function isAuthed(opts: { ctx: Context; next: NextFunction }) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
 
-  if (!validationResult) {
+  // If validation fails or if refresh token is not valid, we return FORBIDDEN
+  if (!validationResult || validationResult === 'shouldLogin') {
     throw new TRPCError({ code: 'FORBIDDEN' });
   }
 }

--- a/packages/send/backend/src/trpc/users.ts
+++ b/packages/send/backend/src/trpc/users.ts
@@ -7,11 +7,11 @@ import {
   getContainersOwnedByUser,
   getUploadsOwnedByUser,
 } from '@/models';
-import { uuidv4 } from '@/utils';
 import { checkCompatibility } from '@/utils/compatibility';
 import { loginEmitter } from '@/ws/login';
 import { TRPCError } from '@trpc/server';
 import { createHash } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 import { on } from 'websocket';
 import { z } from 'zod';
 import {
@@ -75,7 +75,7 @@ export const usersRouter = router({
    *                   description: Complete user data object
    */
   getUserData: trpc.use(isAuthed).query(async ({ ctx }) => {
-    const userData = await getUserById(Number(ctx.user.id));
+    const userData = await getUserById(ctx.user.id);
     return { userData: userData };
   }),
 
@@ -188,7 +188,7 @@ export const usersRouter = router({
     .use(isAuthed)
     .use((props) => useEnvironment(props, ['stage', 'development']))
     .mutation(async ({ ctx }) => {
-      const id = Number(ctx.user.id);
+      const id = ctx.user.id;
       try {
         await resetKeys(id);
         const containers = await getContainersOwnedByUser(id);
@@ -360,7 +360,7 @@ export const usersRouter = router({
     }),
 });
 
-async function handleSuccessfulLogin(email: string, id: number) {
+async function handleSuccessfulLogin(email: string, id: string) {
   const uid = uuidv4();
   // Generate the unique_id with the user's email
   const state = `${uid}____${email}`;

--- a/packages/send/backend/src/types/upload.ts
+++ b/packages/send/backend/src/types/upload.ts
@@ -1,0 +1,4 @@
+export interface Upload {
+  id: `${string}-${string}-${string}-${string}-${string}`;
+  ownerId: string;
+}

--- a/packages/send/backend/src/utils.ts
+++ b/packages/send/backend/src/utils.ts
@@ -23,14 +23,6 @@ export function base64url(source) {
   return encodedSource;
 }
 
-export function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0,
-      v = c == 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 export const getCookie = (
   cookieStr: string | undefined,
   name: string

--- a/packages/send/backend/src/wsUploadHandler.ts
+++ b/packages/send/backend/src/wsUploadHandler.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
 import { Transform } from 'stream';
+import { v4 as uuidv4 } from 'uuid';
 import config from './config';
 import storage from './storage';
 
@@ -40,7 +40,7 @@ class Limiter extends Transform {
 }
 
 async function handleUpload(ws, message, fileStream) {
-  const uploadId = crypto.randomBytes(24).toString('hex');
+  const uploadId = uuidv4();
   const fileInfo = JSON.parse(message);
 
   ws.send(

--- a/packages/send/frontend/src/apps/send/components/AccessLinksList.vue
+++ b/packages/send/frontend/src/apps/send/components/AccessLinksList.vue
@@ -8,7 +8,7 @@ import { vTooltip } from 'floating-vue';
 import { ref, watchEffect } from 'vue';
 
 type Props = {
-  folderId: number;
+  folderId: string;
 };
 
 const sharingStore = useSharingStore();

--- a/packages/send/frontend/src/apps/send/components/CreateAccessLink.vue
+++ b/packages/send/frontend/src/apps/send/components/CreateAccessLink.vue
@@ -11,7 +11,7 @@ import { useClipboard, useDebounceFn } from '@vueuse/core';
 const sharingStore = useSharingStore();
 
 const props = defineProps<{
-  folderId: number;
+  folderId: string;
 }>();
 
 const emit = defineEmits(['createAccessLinkComplete', 'createAccessLinkError']);

--- a/packages/send/frontend/src/apps/send/components/FolderView.vue
+++ b/packages/send/frontend/src/apps/send/components/FolderView.vue
@@ -21,7 +21,7 @@ import DownloadConfirmation from './DownloadConfirmation.vue';
 const folderStore = useFolderStore();
 
 const dayjs = inject(DayJsKey);
-const selectedFolder = ref<number | null>(null);
+const selectedFolder = ref<string | null>(null);
 
 const route = useRoute();
 const router = useRouter();
@@ -57,7 +57,7 @@ const openModal = (item: ItemResponse) => {
 };
 
 const gotoRoute = useDebounceFn(() => {
-  const id = Number(route.params.id);
+  const id = route.params.id as string;
   if (!!id) {
     folderStore.goToRootFolder(id);
     return;
@@ -78,7 +78,7 @@ watch(
   }
 );
 
-function handleClick(id: number) {
+function handleClick(id: string) {
   if (selectedFolder.value === id) {
     router.push({ name: 'folder', params: { id } });
     selectedFolder.value = null;

--- a/packages/send/frontend/src/apps/send/stores/folder-store.types.ts
+++ b/packages/send/frontend/src/apps/send/stores/folder-store.types.ts
@@ -1,44 +1,14 @@
 import { UserResponse } from '@/stores/user-store.types';
+import { Container, Item } from '@/types';
 import { FolderStore as FS } from './folder-store';
 
-export type ContainerResponse = {
-  id: number;
-  name: string;
-  createdAt?: Date;
-  updatedAt?: Date;
-  type: string;
-
-  shareOnly?: boolean;
-  shares?: ShareResponse[];
-  ownerId?: number;
-  owner?: UserResponse;
-  wrappedKey?: string;
-  parentId?: number;
-  parent?: ContainerResponse;
-  children?: ContainerResponse[];
-  items?: ItemResponse[];
-  size?: number;
-};
+export type ContainerResponse = Container;
 
 export type FolderResponse = ContainerResponse;
 
 export type Folder = FolderResponse;
 
-export type ItemResponse = {
-  id: number;
-  name: string;
-  wrappedKey?: string;
-  containerId?: number;
-  container?: ContainerResponse;
-  uploadId: string;
-  type?: string;
-
-  createdAt?: Date;
-  updatedAt?: Date;
-  upload?: Upload;
-};
-
-export type Item = ItemResponse;
+export type ItemResponse = Item;
 
 export type UploadResponse = {
   id?: string;
@@ -59,10 +29,12 @@ export type Upload = UploadResponse;
 
 export type ShareResponse = {
   id?: number;
-  containerId?: number;
+  containerId?: string;
   container?: ContainerResponse;
-  senderId: number;
+  senderId: string;
   sender?: UserResponse;
 };
 
 export type FolderStore = FS;
+
+export { Container, Item };

--- a/packages/send/frontend/src/apps/send/stores/sharing-store.ts
+++ b/packages/send/frontend/src/apps/send/stores/sharing-store.ts
@@ -31,7 +31,7 @@ const useSharingStore = defineStore('sharingManager', () => {
   });
 
   async function createAccessLink(
-    folderId: number,
+    folderId: string,
     password: string,
     expiration: string
   ): Promise<string | null> {
@@ -105,7 +105,7 @@ const useSharingStore = defineStore('sharingManager', () => {
     return await api.call<{ id: string }>(`sharing/exists/${linkId}`);
   }
 
-  async function fetchAccessLinks(folderId: number): Promise<void> {
+  async function fetchAccessLinks(folderId: string): Promise<void> {
     _links.value = await api.call(`containers/${folderId}/links`);
   }
 

--- a/packages/send/frontend/src/lib/challenge.ts
+++ b/packages/send/frontend/src/lib/challenge.ts
@@ -8,7 +8,7 @@ export async function getContainerKeyFromChallenge(
   keychain: Keychain
 ): Promise<{
   unwrappedKey: CryptoKey;
-  containerId: number;
+  containerId: string;
 } | null> {
   const resp = await api.call<{
     challengeKey: string;

--- a/packages/send/frontend/src/lib/download.ts
+++ b/packages/send/frontend/src/lib/download.ts
@@ -15,7 +15,7 @@ export default class Downloader {
 
   async doDownload(
     id: string,
-    folderId: number,
+    folderId: string,
     wrappedKeyStr: string,
     filename: string,
     metrics: ReturnType<typeof useMetricsStore>['metrics'],

--- a/packages/send/frontend/src/lib/keychain.ts
+++ b/packages/send/frontend/src/lib/keychain.ts
@@ -6,7 +6,7 @@ export type JwkKeyPair = Record<'publicKey' | 'privateKey', string>;
 // Stored keys are always strings.
 // They are parsed as needed for encrypting/decrypting.
 export type StoredKey = {
-  [key: number]: string;
+  [key: string]: string;
 };
 
 // Bring in node crypto for use with automated tests.
@@ -396,7 +396,7 @@ export class Keychain {
     return Object.keys(this._keys).length;
   }
 
-  async add(id: number, key: CryptoKey) {
+  async add(id: string, key: CryptoKey) {
     if (!this.rsa.publicKey) {
       throw Error('Missing public key, required for wrapping AES key');
     }
@@ -408,7 +408,7 @@ export class Keychain {
     this._keys[id] = wrappedKeyStr;
   }
 
-  async get(id: number): Promise<CryptoKey> {
+  async get(id: string): Promise<CryptoKey> {
     const wrappedKeyStr = this._keys[id];
     if (!wrappedKeyStr) {
       throw Error(`You don't have the key to decrypt this container`);
@@ -420,13 +420,11 @@ export class Keychain {
     return unwrappedKey;
   }
 
-  remove(id: number): void {
+  remove(id: string): void {
     delete this._keys[id];
-    // const index = `${prefix}${id}`;
-    // this.storage.remove(index);
   }
 
-  async newKeyForContainer(id: number): Promise<void> {
+  async newKeyForContainer(id: string): Promise<void> {
     const key = await this.container.generateContainerKey();
     console.log(`adding key for container id ${id}`);
     await this.add(id, key);
@@ -467,7 +465,7 @@ export class Keychain {
     return keypair;
   }
 
-  async fallbackToStoredKeys(keys: Record<number, string>) {
+  async fallbackToStoredKeys(keys: Record<string, string>) {
     if (!keys) {
       keys = await this._storage.loadKeys();
     }
@@ -476,7 +474,7 @@ export class Keychain {
 
   async load(
     keypairStr?: JwkKeyPair,
-    keys?: Record<number, string>
+    keys?: Record<string, string>
   ): Promise<boolean> {
     try {
       // load keypair jwk

--- a/packages/send/frontend/src/lib/share.ts
+++ b/packages/send/frontend/src/lib/share.ts
@@ -21,7 +21,7 @@ export default class Sharer {
   }
 
   // Creates Invitation
-  async shareContainerWithInvitation(containerId: number, email: string) {
+  async shareContainerWithInvitation(containerId: string, email: string) {
     const user = await this.api.call(`users/lookup/${email}/`);
 
     if (user) {
@@ -78,7 +78,7 @@ export default class Sharer {
   async createShareOnlyContainer(
     items = [],
     containerId = null
-  ): Promise<number | null> {
+  ): Promise<string | null> {
     if (items.length === 0 && !containerId) {
       return null;
     }
@@ -169,7 +169,7 @@ export default class Sharer {
   }
 
   async requestAccessLink(
-    containerId: number,
+    containerId: string,
     password?: string,
     expiration?: string
   ): Promise<string | null> {

--- a/packages/send/frontend/src/lib/upload.ts
+++ b/packages/send/frontend/src/lib/upload.ts
@@ -26,7 +26,7 @@ export default class Uploader {
 
   async doUpload(
     fileBlob: NamedBlob,
-    containerId: number,
+    containerId: string,
     api: ApiConnection,
     progressTracker: ProgressTracker
   ): Promise<Item> {

--- a/packages/send/frontend/src/lib/validations.ts
+++ b/packages/send/frontend/src/lib/validations.ts
@@ -37,7 +37,7 @@ export const validateBackedUpKeys = async (
  * Checks local storage for a user object
  */
 export const validateLocalStorageSession = ({ user }: UserStore) => {
-  if (user?.id != 0) return true;
+  if (user?.id != undefined) return true;
   else return false;
 };
 

--- a/packages/send/frontend/src/stores/keychain-store.ts
+++ b/packages/send/frontend/src/stores/keychain-store.ts
@@ -14,9 +14,13 @@ pros: (more) reactivity?
 type KeychainStore = {
   keychain: Keychain;
   resetKeychain: () => void;
+  addKey: (id: string, key: CryptoKey) => Promise<void>;
+  getKey: (id: string) => Promise<CryptoKey>;
+  removeKey: (id: string) => void;
+  newKeyForContainer: (id: string) => Promise<void>;
 };
 
-const useKeychainStore: () => KeychainStore = defineStore('keychain', () => {
+const useKeychainStore = defineStore('keychain', () => {
   const storage = new Storage();
   const keychain = new Keychain(storage);
 
@@ -24,10 +28,32 @@ const useKeychainStore: () => KeychainStore = defineStore('keychain', () => {
     keychain._init();
   }
 
-  return {
+  async function addKey(id: string, key: CryptoKey) {
+    await keychain.add(id, key);
+  }
+
+  async function getKey(id: string) {
+    return await keychain.get(id);
+  }
+
+  function removeKey(id: string) {
+    keychain.remove(id);
+  }
+
+  async function newKeyForContainer(id: string) {
+    await keychain.newKeyForContainer(id);
+  }
+
+  const store: KeychainStore = {
     keychain,
     resetKeychain,
+    addKey,
+    getKey,
+    removeKey,
+    newKeyForContainer,
   };
+
+  return store;
 });
 
 export default useKeychainStore;

--- a/packages/send/frontend/src/stores/user-store.ts
+++ b/packages/send/frontend/src/stores/user-store.ts
@@ -15,7 +15,7 @@ export interface UserStore {
   login: (loginEmail?: string) => Promise<UserType>;
   loadFromLocalStorage: () => Promise<boolean>;
   store: (
-    newId?: number,
+    newId?: string,
     newTier?: UserTier,
     newEmail?: string
   ) => Promise<void>;
@@ -24,7 +24,7 @@ export interface UserStore {
   updatePublicKey: (jwk: string) => Promise<string>;
   getMozAccountAuthUrl: () => Promise<string>;
   createBackup: (
-    userId: number,
+    userId: string,
     keys: string,
     keypair: string,
     keystring: string,
@@ -35,7 +35,7 @@ export interface UserStore {
 }
 
 export const EMPTY_USER: UserType = {
-  id: 0,
+  id: undefined,
   tier: UserTier.FREE,
   email: '',
 };
@@ -118,7 +118,7 @@ const useUserStore: () => UserStore = defineStore('user', () => {
   }
 
   async function store(
-    newId?: number,
+    newId?: string,
     newTier?: UserTier,
     newEmail?: string
   ): Promise<void> {

--- a/packages/send/frontend/src/stores/user-store.types.ts
+++ b/packages/send/frontend/src/stores/user-store.types.ts
@@ -6,7 +6,7 @@ export type Backup = {
 };
 
 export type UserResponse = {
-  id: number;
+  id: string;
   email: string;
   tier: string;
   createdAt?: Date;

--- a/packages/send/frontend/src/test/apps/lockbox/components/FolderVue.test.ts
+++ b/packages/send/frontend/src/test/apps/lockbox/components/FolderVue.test.ts
@@ -57,12 +57,12 @@ describe('FolderView', () => {
     vi.runAllTimers();
 
     // Check if goToRootFolder was called with new id
-    expect(goToRootFolderSpy).toBeCalledWith(null);
+    expect(goToRootFolderSpy).toBeCalledWith('0');
 
     await router.push({ name: 'folder', params: { id: '123' } });
     await wrapper.vm.$nextTick();
     vi.runAllTimers();
 
-    expect(goToRootFolderSpy).toBeCalledWith(123);
+    expect(goToRootFolderSpy).toBeCalledWith('123');
   });
 });

--- a/packages/send/frontend/src/test/stores/user-store.test.ts
+++ b/packages/send/frontend/src/test/stores/user-store.test.ts
@@ -53,7 +53,7 @@ describe('User Store', () => {
         .spyOn(useApiStore().api, 'call')
         .mockResolvedValueOnce({
           user: {
-            id: 1,
+            id: '1',
             tier: 3,
           },
         });
@@ -75,7 +75,7 @@ describe('User Store', () => {
       );
 
       expect(result).toEqual({
-        id: 1,
+        id: '1',
         tier: 3,
         email,
       });
@@ -88,7 +88,7 @@ describe('User Store', () => {
         .spyOn(useApiStore().api, 'call')
         .mockResolvedValueOnce({
           user: {
-            id: 1,
+            id: '1',
             tier: UserTier.EPHEMERAL,
           },
         });
@@ -110,7 +110,7 @@ describe('User Store', () => {
       );
 
       expect(result).toEqual({
-        id: 1,
+        id: '1',
         tier: UserTier.EPHEMERAL,
         email,
       });
@@ -119,7 +119,7 @@ describe('User Store', () => {
     it('should use the stored email if no email is provided', async () => {
       userStore.user.email = 'stored@example.com'; // Assume this is set from a previous action
       const loginResponse = {
-        id: 4,
+        id: '4',
         tier: UserTier.FREE,
         email: userStore.user.email,
       };
@@ -162,7 +162,7 @@ describe('User Store', () => {
       const apiCallMock = vi
         .spyOn(useApiStore().api, 'call')
         .mockResolvedValueOnce({
-          id: 1,
+          id: '1',
           tier: 3,
           email,
         });
@@ -175,7 +175,7 @@ describe('User Store', () => {
         'POST'
       );
       expect(result).toEqual({
-        id: 1,
+        id: '1',
         tier: 3,
         email,
       });
@@ -185,7 +185,7 @@ describe('User Store', () => {
   describe('load', () => {
     it('should load user data from storage and populate the store', async () => {
       const storedUserData = {
-        id: 2,
+        id: '2',
         tier: UserTier.FREE,
         email,
       };
@@ -220,9 +220,9 @@ describe('User Store', () => {
       const newTier = UserTier.PRO;
       const newEmail = 'new@example.com';
       const storageMock = vi.spyOn(Storage.prototype, 'storeUser');
-      await userStore.store(newId, newTier, newEmail);
+      await userStore.store(newId.toString(), newTier, newEmail);
       expect(storageMock).toHaveBeenCalledWith({
-        id: newId,
+        id: newId.toString(),
         tier: newTier,
         email: newEmail,
       });
@@ -248,7 +248,7 @@ describe('User Store', () => {
     it('should populate user store with user data from session', async () => {
       const userData = {
         user: {
-          id: 1,
+          id: '1',
           email,
           tier: UserTier.PRO,
         },
@@ -291,12 +291,13 @@ describe('User Store', () => {
 
   describe('getPublicKey', () => {
     it('should retrieve a public key for a given user', async () => {
-      const userId = 0; // Assuming the user ID is known for the test
+      const userId = 'user-uuid'; // Assuming the user ID is known for the test
+      userStore.user.id = userId; // Simulate loading from local storage
       const apiCallMock = vi
         .spyOn(useApiStore().api, 'call')
         .mockResolvedValueOnce({ publicKey });
 
-      const result = await userStore.getPublicKey(userId);
+      const result = await userStore.getPublicKey();
 
       expect(apiCallMock).toHaveBeenCalledWith(`users/publickey/${userId}`);
       expect(result).toBe(publicKey);
@@ -336,7 +337,7 @@ describe('User Store', () => {
 
   describe('createBackup', () => {
     it('should create a backup for the user and handle the data correctly', async () => {
-      const userId = 1;
+      const userId = '1';
       const backupData = {
         keys: 'someKeys',
         keypair: 'someKeypair',

--- a/packages/send/frontend/src/types.ts
+++ b/packages/send/frontend/src/types.ts
@@ -52,7 +52,7 @@ export interface Api {
 
 // interfaces used for API responses
 export interface UserType {
-  id: number;
+  id: string;
   email: string;
   tier?: UserTier;
   createdAt?: Date;
@@ -64,37 +64,45 @@ export interface Profile {
   mozid: string;
   avatar: string;
   user?: UserType;
-  userId?: number;
+  userId?: string;
 }
 
 export interface Share {
   id?: number;
-  containerId?: number;
+  containerId?: string;
   container?: Container;
-  senderId: number;
+  senderId: string;
   sender?: UserType;
 }
 
+export enum ContainerType {
+  CONVERSATION = 'CONVERSATION',
+  FOLDER = 'FOLDER',
+}
+
+export enum ItemType {
+  MESSAGE = 'MESSAGE',
+  FILE = 'FILE',
+}
+
 export interface Container {
-  id: number;
+  id: string;
   name: string;
   createdAt?: Date;
   updatedAt?: Date;
-  type: string;
+  type: ContainerType;
 
   shareOnly?: boolean;
   shares?: Share[];
-  ownerId?: number;
+  ownerId?: string;
   owner?: UserType;
   wrappedKey?: string;
-  parentId?: number;
+  parentId?: string;
   parent?: Container;
   children?: Container[];
   items?: Item[];
   size?: number;
 }
-
-export interface Folder extends Container {}
 
 export interface Item {
   id: number;
@@ -102,9 +110,9 @@ export interface Item {
   uploadId: string;
 
   wrappedKey?: string;
-  containerId?: number;
+  containerId?: string;
   container?: Container;
-  type?: string;
+  type?: ItemType;
 
   createdAt?: Date;
   updatedAt?: Date;
@@ -114,12 +122,15 @@ export interface Item {
 export interface Upload {
   id?: string;
   size?: number;
-  ownerId?: number;
+  ownerId?: string;
   type?: string;
   createdAt?: Date;
   owner?: {
     email: string;
   };
+  // deprecated
+  expired?: boolean;
+  daysToExpiry?: number;
 }
 
 export interface Backup {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       prisma:
         specifier: ^5.22.0
         version: 5.22.0
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vite:
         specifier: '>=5.4.17'
         version: 6.2.5(@types/node@22.14.0)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
@@ -5653,6 +5656,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   uuid@9.0.1:
@@ -12139,6 +12146,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
Closes #585 

This PR changes all containerId and userId to use `uuid` string instead of numbers. To do this I also.
- Applied db migrations to modify tables
- Modified data types to match
- Updated test suites

Merged pre approved #592 