### PR TITLE
Fix/remove auth middleware from get storage type

### DIFF
--- a/packages/send/backend/package.json
+++ b/packages/send/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-backend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "keywords": [],
   "license": "ISC",

--- a/packages/send/backend/src/trpc/containers.ts
+++ b/packages/send/backend/src/trpc/containers.ts
@@ -138,8 +138,6 @@ export const containersRouter = router({
    *       - Storage
    *     summary: Get storage type configuration
    *     description: Returns whether the system is using bucket storage or not
-   *     security:
-   *       - bearerAuth: []
    *     responses:
    *       200:
    *         description: Storage type configuration
@@ -152,7 +150,7 @@ export const containersRouter = router({
    *                   type: boolean
    *                   description: Whether the system is using bucket storage
    */
-  getStorageType: t.use(isAuthed).query(async () => {
+  getStorageType: t.query(async () => {
     if (typeof IS_USING_BUCKET_STORAGE === 'boolean') {
       return { isBucketStorage: IS_USING_BUCKET_STORAGE };
     }

--- a/packages/send/e2e/pages/dashboard.ts
+++ b/packages/send/e2e/pages/dashboard.ts
@@ -67,12 +67,12 @@ export async function log_out_restore_keys({ page }: PlaywrightProps) {
   // restore keys
   secondPage.on("dialog", (dialog) => dialog.accept());
   const passphrase = shareLinks.shift();
-  await secondPage.goto("http://localhost:5173/send/profile");
+  await secondPage.goto("/send/profile");
   await restorekeyInput.fill(passphrase!);
   await restoreKeysButton.click();
 
   // look for folder (only shows when keys are restored)
-  await secondPage.goto("http://localhost:5173/send");
+  await secondPage.goto("/send");
 
   // Check that default folder exists
   await secondPage.waitForSelector(folderRowSelector);

--- a/packages/send/e2e/testUtils.ts
+++ b/packages/send/e2e/testUtils.ts
@@ -1,4 +1,10 @@
-import { BrowserContext, expect, firefox, Page } from "@playwright/test";
+import {
+  Browser,
+  BrowserContext,
+  expect,
+  firefox,
+  Page,
+} from "@playwright/test";
 import { readFileSync } from "fs";
 
 import { fileLocators } from "./locators";
@@ -34,14 +40,42 @@ export async function saveClipboardItem(page: Page) {
 export async function setup_browser() {
   const browser = await firefox.launch();
 
-  const context = await browser.newContext({
+  // Base context options
+  const contextOptions = {
     ignoreHTTPSErrors: true,
+    viewport: { width: 1280, height: 720 },
+    acceptDownloads: true,
+    serviceWorkers: "block" as const,
+    bypassCSP: true,
+  };
+
+  // Create main context with storage state
+  const context = await browser.newContext({
+    ...contextOptions,
     storageState: storageStatePath,
   });
 
   const page = await context.newPage();
 
   return { context, page };
+}
+
+export async function create_incognito_context(browser: Browser) {
+  // Create incognito context with clean state
+  const incognitoContext = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1280, height: 720 },
+    acceptDownloads: true,
+    serviceWorkers: "block" as const,
+    bypassCSP: true,
+    // Start with a clean state
+    storageState: {
+      cookies: [],
+      origins: [],
+    },
+  });
+
+  return incognitoContext;
 }
 
 export const dragAndDropFile = async (

--- a/packages/send/frontend/package.json
+++ b/packages/send/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/send/frontend/public/manifest.json
+++ b/packages/send/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Thunderbird Team",
   "name": "Thunderbird Send",
   "description": "Thunderbird and friends",

--- a/packages/send/frontend/src/apps/send/views/ViewShare.vue
+++ b/packages/send/frontend/src/apps/send/views/ViewShare.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import FolderTree from '@/apps/send/components/FolderTree.vue';
 import useSharingStore from '@/apps/send/stores/sharing-store';
+import logger from '@/logger';
+import { Container } from '@/types';
 import { onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 const route = useRoute();
 const sharingStore = useSharingStore();
 
-const folder = ref(null);
+const folder = ref<Container>(null);
 const containerId = ref(null);
 
 onMounted(async () => {
-  console.log(`ViewShare ready to get folder for hash`);
+  logger.info(`ViewShare ready to get folder for hash`);
   // Using route.params.linkId, get the folder contents
   const container = await sharingStore.getSharedFolder(
     route.params.linkId as string
@@ -21,7 +23,8 @@ onMounted(async () => {
 });
 </script>
 <template>
-  <h1>Shared files for folder id: {{ containerId }}</h1>
-
-  <FolderTree :folder="folder" :container-id="containerId" />
+  <div v-if="folder?.id">
+    <h1>Shared files for folder id: {{ containerId }}</h1>
+    <FolderTree :folder="folder" :container-id="containerId" />
+  </div>
 </template>

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -13,10 +13,10 @@
     "predev": "./scripts/pre-flight.sh",
     "dev": "docker compose up --build --force-recreate -d && docker compose logs -f",
     "dev:detach": "docker compose up -d --build",
-    "teardown": "docker compose down",
     "setup": "./scripts/setup.sh",
     "setup:local": "./scripts/setup.sh && bun run scripts/local.ts",
     "sort-package-json": "sort-package-json",
+    "teardown": "docker compose down",
     "test:e2e": "pnpm exec playwright test --headed",
     "test:e2e:ci": "./scripts/e2e.sh",
     "test:e2e:ui": "pnpm exec playwright test --ui"

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -13,6 +13,7 @@
     "predev": "./scripts/pre-flight.sh",
     "dev": "docker compose up --build --force-recreate -d && docker compose logs -f",
     "dev:detach": "docker compose up -d --build",
+    "teardown": "docker compose down",
     "setup": "./scripts/setup.sh",
     "setup:local": "./scripts/setup.sh && bun run scripts/local.ts",
     "sort-package-json": "sort-package-json",

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-suite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "keywords": [],
   "license": "ISC",

--- a/packages/send/playwright.config.ts
+++ b/packages/send/playwright.config.ts
@@ -25,20 +25,42 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: "http://localhost:5173",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
     actionTimeout: 10_000,
     screenshot: "only-on-failure",
     video: "retain-on-failure",
+
+    /* Context settings */
+    contextOptions: {
+      ignoreHTTPSErrors: true,
+      viewport: { width: 1280, height: 720 },
+      acceptDownloads: true,
+      // Default permissions that should work across browsers
+      permissions: ["geolocation"],
+      // Recommended defaults for better stability
+      serviceWorkers: "block",
+      bypassCSP: true,
+    },
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: {
+        ...devices["Desktop Firefox"],
+        // Firefox-specific settings
+        launchOptions: {
+          firefoxUserPrefs: {
+            "dom.push.enabled": false,
+            "dom.webnotifications.enabled": false,
+            "privacy.trackingprotection.enabled": false,
+          },
+        },
+      },
     },
 
     // {


### PR DESCRIPTION
This PR fixes a bug that doesn't allow anonymous users to download files. 
- Added testing coverage to test downloads in incognito mode
- Removed auth middleware from getStorageType since it's not a critical security problem
- Bumped versions
- Fixed some runtime errors

### Version Updates:

Updated the version in package.json files for send-backend, send-frontend, and send-suite from 2.0.0 to 2.0.1 to reflect minor updates.

### Backend Changes:

Removed the bearerAuth security requirement from the getStorageType endpoint in containers.ts and dropped the isAuthed middleware for this query, simplifying access to storage type information.

### E2E Testing Enhancements:

Introduced a new create_incognito_context function in testUtils.ts to support testing in incognito mode, and updated workflows to include incognito tests for file downloads.

Refactored E2E test structure in send.spec.ts to group tests logically (authentication and file workflows) and added shared setup and cleanup logic for better maintainability.

Updated setup_browser in testUtils.ts to include additional context options like viewport size and service worker blocking for improved test stability.

### Frontend Improvements:

Replaced console.log with logger.info in ViewShare.vue for better logging practices and added conditional rendering for folder-related UI elements.

### Configuration Updates:

Set a baseURL in playwright.config.ts to streamline E2E test navigation and added browser-specific settings for Firefox to disable unnecessary features like push notifications and tracking protection.